### PR TITLE
fix: make entire row clickable on home page instead of just icons

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -59,23 +59,31 @@
             width: 300px; /* Set a fixed width for uniform boxes */
             margin: 10px auto; /* Center the list items */
         }
-        li:hover {
+        li {
+            padding: 0;
+        }
+        li a {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            padding: 10px;
+            color: #ffffff;
+            text-decoration: none;
+            transition: background 0.3s ease, transform 0.3s ease;
+            border-radius: 5px;
+        }
+        li a:hover {
             background: rgba(255, 255, 255, 0.2);
             transform: translateY(-5px);
         }
-        a.icon-link {
-            color: #ffd700;
-            text-decoration: none;
+        .icon {
             font-size: 1.5em;
             margin-right: 10px;
-            transition: transform 0.3s ease;
-        }
-        a.icon-link:hover {
-            transform: scale(1.2);
         }
         span {
-            flex-grow: 1; /* Ensure the text spans the remaining space */
-            text-align: left; /* Align text to the left within the box */
+            flex-grow: 1;
+            text-align: left;
         }
     </style>
 </head>
@@ -85,16 +93,16 @@
     
     <h2>3 Available LLMs to Choose From:</h2>
     <ul>
-        <li><a class="icon-link" href="/llama">⚙️</a><span>Meta-Llama-3-8B-Instruct</span></li><br>
-        <li><a class="icon-link" href="/gemma">⚙️</a><span>Gemma-2b</span></li><br>
-        <li><a class="icon-link" href="/mistralai">⚙️</a><span>Mistral-7B-Instruct-v0.2</span></li>
+        <li><a href="/llama"><span class="icon">⚙️</span><span>Meta-Llama-3-8B-Instruct</span></a></li><br>
+        <li><a href="/gemma"><span class="icon">⚙️</span><span>Gemma-2b</span></a></li><br>
+        <li><a href="/mistralai"><span class="icon">⚙️</span><span>Mistral-7B-Instruct-v0.2</span></a></li>
     </ul>
     
     <h2>3 Available URL Paths:</h2>
     <ul>
-        <li><a class="icon-link" href="/llama">🔗</a><span><code>/llama</code></span></li><br>
-        <li><a class="icon-link" href="/gemma">🔗</a><span><code>/gemma</code></span></li><br>
-        <li><a class="icon-link" href="/mistralai">🔗</a><span><code>/mistralai</code></span></li>
+        <li><a href="/llama"><span class="icon">🔗</span><span><code>/llama</code></span></a></li><br>
+        <li><a href="/gemma"><span class="icon">🔗</span><span><code>/gemma</code></span></a></li><br>
+        <li><a href="/mistralai"><span class="icon">🔗</span><span><code>/mistralai</code></span></a></li>
     </ul>
 </body>
 </html>


### PR DESCRIPTION
## Description

### Summary
Previously, only the small ⚙️ and 🔗 icons were clickable on the home page. Clicking the text labels did not trigger navigation. This PR makes the entire row/card clickable to improve usability and accessibility.

## Related Issue
Fixes #42

## Motivation and Context
Currently, users must click small icons to navigate to model endpoints. This creates a poor user experience and reduces accessibility, especially on mobile devices.

Making the entire row clickable:
- improves usability
- increases click target size
- enhances accessibility
- aligns with modern UI design patterns

## What Changed
- Wrapped entire <li> content inside <a> tags
- Updated CSS so links span the full width of the container
- Hover and focus styles now apply to the entire row

## Before
- Only clicking the small icon navigated to the LLM page
- Clicking the text did nothing

## After
- Entire row is clickable
- Navigation works from anywhere on the item
- Improved accessibility and user experience

## How Has This Been Tested?

Environment:
Local Flask development server

Steps:
1. Run:
   flask --app app.py run
2. Open:
   http://127.0.0.1:5000
3. Click anywhere on any LLM row
4. Confirm navigation works correctly

## Screenshots (if appropriate)
Before
<img width="1307" height="930" alt="Screenshot From 2026-02-20 13-01-20" src="https://github.com/user-attachments/assets/45f30f7e-c462-4d66-aeb5-b106d7e566e0" />

After

https://github.com/user-attachments/assets/52be8139-aee6-4cd6-a5a5-747aeafce244


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.