### PR TITLE
Fix: News extractor with boundary checks and error handling

### DIFF
--- a/cybernews/extractor.py
+++ b/cybernews/extractor.py
@@ -102,39 +102,51 @@ class Extractor(Performance):
         raw_news_date = soup.select(value["date"]) if value["date"] is not None else ""
 
         for index in range(len(news_headlines)):
-            if raw_news_date:
-                news_date = self._news_date_extractor(
-                    raw_news_date[index].text.strip(), raw_news_date
-                )
-            else:
-                news_date = "N/A"
+            try:
+                if raw_news_date and index < len(raw_news_date):
+                    news_date = self._news_date_extractor(
+                        raw_news_date[index].text.strip(), raw_news_date
+                    )
+                else:
+                    news_date = "N/A"
 
-            if raw_news_author:
-                news_author = self._author_name_extractor(
-                    raw_news_author[index].text.strip()
-                )
-            else:
-                news_author = "N/A"
+                if raw_news_author and index < len(raw_news_author):
+                    news_author = self._author_name_extractor(
+                        raw_news_author[index].text.strip()
+                    )
+                else:
+                    news_author = "N/A"
 
-            if self._check_ad(news_date):
+                if self._check_ad(news_date):
+                    continue
+
+                if index >= len(news_url) or not self.valid_url_check(news_url[index].get("href", "")):
+                    continue
+
+                headlines_text = news_headlines[index].text.strip()
+                full_news_text = news_full_news[index].text.strip() if index < len(news_full_news) else ""
+
+                if self.spam_content_check(headlines_text + " " + full_news_text):
+                    continue
+
+                img_url = ""
+                if index < len(news_img_url):
+                    img_tag = news_img_url[index]
+                    img_url = img_tag.get("data-src") or img_tag.get("src") or ""
+
+                complete_news = {
+                    "id": self.sorting.ordering_date(news_date),
+                    "headlines": headlines_text,
+                    "author": news_author,
+                    "fullNews": full_news_text,
+                    "newsURL": news_url[index]["href"],
+                    "newsImgURL": img_url,
+                    "newsDate": news_date,
+                }
+                news_data_from_single_news.append(complete_news)
+            except Exception as e:
+                print(f"Error processing news item {index} from {url}: {e}")
                 continue
-
-            if not self.valid_url_check(news_url[index]["href"]):
-                continue
-
-            if self.spam_content_check(news_headlines[index].text.strip() + " " + news_full_news[index].text.strip()):
-                continue
-
-            complete_news = {
-                "id": self.sorting.ordering_date(news_date),
-                "headlines": news_headlines[index].text.strip(),
-                "author": news_author,
-                "fullNews": news_full_news[index].text.strip(),
-                "newsURL": news_url[index]["href"],
-                "newsImgURL": news_img_url[index]["data-src"],
-                "newsDate": news_date,
-            }
-            news_data_from_single_news.append(complete_news)
 
         # Remove duplicates before sorting
         unique_news_data_from_single_news = self._remove_duplicates(news_data_from_single_news)


### PR DESCRIPTION
### Summary
This PR fixes stability issues in the web news extraction logic that were causing the application to crash on malformed or non-standard HTML responses from news sources as explained in #76 .

### Changes
- **Implemented Boundary Checks**: Added `index < len(list)` checks for all scraped elements (dates, authors, full news, images) to prevent `IndexError`.
- **Defensive Attribute Access**: Switched to `.get()` for dictionary/attribute access to prevent `KeyError`.
- **Image Fallback**: Added a fallback mechanism for image URLs (checks `data-src`, then `src`).
- **Per-Item Failure Isolation**: Wrapped the internal extraction loop in a `try...except` block. This ensures that a single malformed news item doesn't fail the entire scraping task for a URL.

### Verification Results
- Ran `PYTHONPATH=. python3 tests/unitTest_cybernews.py` -> **Passed**.
- Manually verified that the scraper successfully recovers from partial scraping failures and returns valid news items for other articles on the same page.
<img width="849" height="238" alt="image" src="https://github.com/user-attachments/assets/bf6fdaa4-e260-400a-896f-c9637dca7d96" />
