### PR TITLE
fix: return proper JSON response for 404 error handler

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -49,4 +49,4 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    return jsonify({"error": "Route not found"}), 404


### PR DESCRIPTION
## Problem
The 404 error handler in `routes/NewsRoutes.py` had two issues:
1. No return statement — Flask requires error handlers to return a response
2. Used `g.news_controller` which may not be set if the error occurs before any route is matched, causing an additional crash

## Fix
Replaced the broken handler with a simple, reliable JSON response that always works regardless of application state.

## Changes
- `routes/NewsRoutes.py`: Fixed 404 handler to return proper JSON response with status code

## Testing
Hitting any undefined route now returns:
`{"error": "Route not found"}` with HTTP 404