### PR TITLE
fix: add proper error handling for unhandled exceptions in news routes

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -18,7 +18,10 @@ set route for different LLM models
 def set_llm_route(llm_name):
     if llm_name == "favicon.ico":
         return "", 204  # No Content response for favicon requests
-    g.news_controller = NewsController(llm_name)
+    try:
+        g.news_controller = NewsController(llm_name)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     return render_template("llm.html", llm_name=llm_name)
 
 
@@ -27,8 +30,13 @@ return news without considering keywords
 """
 @routes.route("/<llm_name>/news", methods=["GET"])
 def getNews_route(llm_name):
-    g.news_controller = NewsController(llm_name)
-    news = g.news_controller.getNews()
+    try:
+        g.news_controller = NewsController(llm_name)
+        news = g.news_controller.getNews()
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": "Failed to retrieve news", "details": str(e)}), 500
     return render_template("news.html", data=news)
 
 
@@ -38,10 +46,17 @@ return news based on certain keywords
 @routes.route("/<llm_name>/news_keywords", methods=["GET"])
 def getNewsWithKeywords_route(llm_name):
     # get list of keywords as argument from User's request
-    g.news_controller = NewsController(llm_name)
     user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
-    return render_template("news_key.html", data=data,keyword=user_keywords[0])
+    if not user_keywords or not user_keywords[0].strip():
+        return jsonify({"error": "At least one keyword must be provided via ?keywords=<value>"}), 400
+    try:
+        g.news_controller = NewsController(llm_name)
+        data = g.news_controller.getNewsWithKeywords(user_keywords[0])
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": "Failed to retrieve news", "details": str(e)}), 500
+    return render_template("news_key.html", data=data, keyword=user_keywords[0])
 
 
 """
@@ -49,4 +64,4 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    return jsonify({"error": "Route not found", "status": 404}), 404


### PR DESCRIPTION
## Related Issue
Closes #58

## Problem

All news routes in `routes/NewsRoutes.py` lacked any error handling, causing
the API to return raw unformatted 500 Internal Server Errors under several
common failure conditions. The 404 handler was also silently broken.

## Root Cause Analysis

| Location | Bug | Error |
|---|---|---|
| `notFound_route` L52 | Result of `g.news_controller.notFound(error)` was never `return`ed — Flask received no response from the handler | Broken 404 responses |
| `notFound_route` L52 | `g.news_controller` is only set inside other routes — a direct 404 hit (e.g. `/unknown`) finds no controller on `g` | `AttributeError` inside error handler |
| `set_llm_route` L21 | `NewsController(llm_name)` raises `ValueError` for unknown model names with no handler | Unhandled 500 |
| `getNews_route` L30-31 | Same unguarded `NewsController` init; `getNews()` can also throw on LLM/DB failure | Unhandled 500 |
| `getNewsWithKeywords_route` L43 | `user_keywords[0]` with no bounds check — empty `?keywords=` or missing param crashes immediately | `IndexError` → 500 |
| `getNewsWithKeywords_route` L41-43 | Same unguarded init and service call | Unhandled 500 |

## Changes Made

### `routes/NewsRoutes.py`
- **`set_llm_route`**: wrap `NewsController(llm_name)` in `try/except ValueError` — returns `400` with a JSON error message for unknown model names
- **`getNews_route`**: wrap controller init and `getNews()` call — `ValueError` returns `400`, any other exception returns `500` with a descriptive JSON body instead of a raw crash
- **`getNewsWithKeywords_route`**: validate `user_keywords` before accessing index `[0]` and return `400` with a helpful message; same try/except wrapping as above
- **`notFound_route`**: replaced broken `g.news_controller.notFound(error)` call with a self-contained `return jsonify({"error": "Route not found", "status": 404}), 404` — no longer depends on `g.news_controller` being set

## Before / After

**Before** — hitting `/badmodel/news`: