### PR TITLE
fix: remove fabrication instruction and add anti-hallucination guardrails to LLM prompts

### DIFF
--- a/prompts/withkey.json
+++ b/prompts/withkey.json
@@ -1,7 +1,7 @@
 [
     {
         "role": "system",
-        "content": "You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+        "content": "You are a news analyzer. You will only use the news articles explicitly provided to you. You must never fabricate, invent, or infer any information that is not present in the provided data."
     },
     {
         "role": "user",
@@ -21,6 +21,6 @@
     },
     {
         "role": "user",
-        "content": "Please give me a list of the most recent cybersecurity news based on the news and keyword given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news. Return the news strictly in the required format. do not leave any key empty. if you do not have information, make up some."
+        "content": "Please give me a list of the most recent cybersecurity news based only on the news and keywords given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news. If any field (title, source, date, or URL) is missing for a news item, skip that item entirely. If no news matches the given keywords, return an empty response. Do not fabricate or invent any information."
     }
 ]

--- a/prompts/withoutkey.json
+++ b/prompts/withoutkey.json
@@ -1,7 +1,7 @@
 [
     {
         "role": "system",
-        "content": "You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+        "content": "You are a news analyzer. You will only use the news articles explicitly provided to you. You must never fabricate, invent, or infer any information that is not present in the provided data."
     },
     {
         "role": "user",
@@ -13,6 +13,6 @@
     },
     {
         "role": "user",
-        "content": "Please give me a list of the most recent cybersecurity news based on the news given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points OR number list. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news."
+        "content": "Please give me a list of the most recent cybersecurity news based only on the news given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points OR number list. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news. If any field (title, source, date, or URL) is missing for a news item, skip that item entirely. Do not fabricate or invent any information."
     }
 ]


### PR DESCRIPTION
## Related Issue
Closes #87

## Problem
`prompts/withkey.json` contained an explicit instruction telling the LLM to
fabricate data whenever a field was missing:

> *"do not leave any key empty. if you do not have information, **make up some**."*

For a cybersecurity news API this is a critical issue — the LLM was being
actively encouraged to invent news titles, URLs, dates, and sources. Neither
prompt file restricted the LLM to only the provided data, leaving it free to
supplement with information from its training knowledge.

## Root Cause

| File | Problem |
|---|---|
| `withkey.json` system prompt | Vague role definition with no data boundaries |
| `withkey.json` user prompt | Explicit `"if you do not have information, make up some"` instruction |
| `withkey.json` user prompt | No handling for the case where no news matches the keywords |
| `withoutkey.json` system prompt | Same vague role, no fabrication boundary |
| `withoutkey.json` user prompt | No explicit anti-fabrication guardrail |

## Changes Made

### Both files — system prompt
Replaced the vague role description with an explicit data boundary:
> *"You will only use the news articles explicitly provided to you. You must never fabricate, invent, or infer any information that is not present in the provided data."*

### `withkey.json` — user prompt
- Removed: `"do not leave any key empty. if you do not have information, make up some."`
- Added: `"If any field (title, source, date, or URL) is missing for a news item, skip that item entirely."`
- Added: `"If no news matches the given keywords, return an empty response."`
- Added: `"Do not fabricate or invent any information."`
- Changed `"based on"` → `"based only on"` to restrict to provided data

### `withoutkey.json` — user prompt
- Added: `"If any field (title, source, date, or URL) is missing for a news item, skip that item entirely."`
- Added: `"Do not fabricate or invent any information."`
- Changed `"based on"` → `"based only on"` to restrict to provided data

## Impact
The LLM will now skip incomplete news items instead of inventing data for
missing fields, and will return an empty response rather than hallucinating
news that does not match the requested keywords. All output is grounded
strictly in the provided news feed.