### PR TITLE
Fix 404 handler response path

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -49,4 +49,5 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    controller = getattr(g, "news_controller", news_controller)
+    return controller.notFound(error)


### PR DESCRIPTION
## Summary`n- return a 404 response from the handler instead of dropping it`n- use the default controller when request-local controller is unavailable`n`n## Why`nThis prevents empty/failed 404 responses and avoids attribute errors when an invalid route is hit directly.