### PR TITLE
Harden NewsService LLM output parsing

### DIFF
--- a/services/NewsService.py
+++ b/services/NewsService.py
@@ -98,29 +98,25 @@ class NewsService:
     def toJSON(self, data: str):
         if len(data) == 0:
             return {}
-        news_list = data.split("\n")
+        news_list = [line.strip() for line in data.split("\n") if line.strip()]
         news_list_json = []
-        news_list.pop(0)
+
         for item in news_list:
-            # Avoid dirty data
-            if len(item) == 0:
+            # Skip non-news lines from the model output
+            if not item.startswith("[") or "]" not in item:
                 continue
+
             # Remove leading and trailing square brackets and split by comma and strip extra spaces
             data_list = [item.strip().strip('"') for item in item.strip('[').strip(']').split(',')]
             data_list = [val.strip() for val in data_list]
+            if len(data_list) < 4:
+                continue
 
-            for i in data_list:
-                print(i)
-                print("----")
-                
-            print(data_list)
             # Assign default values for missing elements
-            start_index = data_list[0].find('[') if len(data_list) > 0 else -1
-            end_index = data_list[3].find(']') if len(data_list) > 3 else -1
-            title = data_list[0][start_index+1:] if len(data_list) > 0 else "No title provided"
+            title = data_list[0] if len(data_list) > 0 else "No title provided"
             source = data_list[1] if len(data_list) > 1 else "No source provided"
             date = data_list[2] if len(data_list) > 2 else "No date provided"
-            url = data_list[3][:end_index-1] if len(data_list) > 3 else "No URL provided"
+            url = data_list[3].rstrip("]") if len(data_list) > 3 else "No URL provided"
 
             news_item = {
                 "title": title,
@@ -130,5 +126,4 @@ class NewsService:
             }
             news_list_json.append(news_item)
 
-        news_list_json.pop()
         return news_list_json


### PR DESCRIPTION
## Summary`n- remove debug print statements from JSON conversion path`n- skip malformed/non-news lines and partial rows safely`n- stop using list pops that can fail on shorter outputs`n`n## Why`nLLM outputs can be noisy; this keeps conversion robust and avoids parser crashes.