### PR TITLE
Validate Pinecone API key at startup

### DIFF
--- a/config/Database.py
+++ b/config/Database.py
@@ -6,6 +6,10 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 PINECONE_API = dotenv_values(".env").get("PINECONE_API_KEY")
+if not PINECONE_API:
+    raise RuntimeError(
+        "PINECONE_API_KEY is missing. Copy .env.example to .env and set PINECONE_API_KEY."
+    )
 
 client = Pinecone(api_key=PINECONE_API)
 index_name = "cybernews-index"


### PR DESCRIPTION
## Summary`n- add an explicit check for missing `PINECONE_API_KEY``n- raise a clear setup error with guidance to use `.env.example``n`n## Why`nFailing fast with a clear message improves setup troubleshooting.