### PR TITLE
Fix chronological ordering and add sorting tests

### DIFF
--- a/cybernews/sorting.py
+++ b/cybernews/sorting.py
@@ -35,6 +35,18 @@ class Sorting:
 
         return news
 
+    def _ordering_key(self, individual_news):
+        news_date = individual_news.get("newsDate", "N/A")
+        date_order = self.ordering_date(news_date)
+        if date_order != 1:
+            return date_order
+
+        existing_id = individual_news.get("id", 1)
+        try:
+            return int(existing_id)
+        except (TypeError, ValueError):
+            return 1
+
     """
         Ordering Date
     """
@@ -67,9 +79,7 @@ class Sorting:
     """
 
     def ordering_news(self, news):
-        data = sorted(
-            news, key=lambda individual_news: individual_news["id"], reverse=True
-        )
+        data = sorted(news, key=self._ordering_key, reverse=True)
 
         data = self._ordering_id(data)
         return data

--- a/tests/unitTest_sorting.py
+++ b/tests/unitTest_sorting.py
@@ -1,0 +1,38 @@
+import unittest
+
+from cybernews.sorting import Sorting
+
+
+class TestSorting(unittest.TestCase):
+    def setUp(self):
+        self.sorting = Sorting()
+
+    def test_ordering_news_prefers_news_date_over_existing_id(self):
+        news = [
+            {"id": 9999999999, "headlines": "older", "newsDate": "January 01, 2024"},
+            {"id": 2, "headlines": "newer", "newsDate": "January 01, 2025"},
+            {"id": 3, "headlines": "unknown", "newsDate": "N/A"},
+        ]
+
+        ordered = self.sorting.ordering_news(news)
+        headlines = [item["headlines"] for item in ordered]
+
+        self.assertEqual(headlines[0], "newer")
+        self.assertEqual(headlines[1], "older")
+        self.assertEqual(headlines[2], "unknown")
+
+    def test_ordering_news_assigns_unique_ids(self):
+        news = [
+            {"id": 1, "headlines": "a", "newsDate": "N/A"},
+            {"id": 2, "headlines": "b", "newsDate": "N/A"},
+            {"id": 3, "headlines": "c", "newsDate": "N/A"},
+        ]
+
+        ordered = self.sorting.ordering_news(news)
+        generated_ids = [item["id"] for item in ordered]
+
+        self.assertEqual(len(generated_ids), len(set(generated_ids)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary`n- sort news using parsed `newsDate` with a safe fallback, instead of relying on mutable `id` fields`n- keep UUID generation as an identifier step after ordering`n- add unit tests for date-priority ordering and generated ID uniqueness`n`n## Why`nThe previous flow could produce random ordering after IDs were reassigned. This makes ordering deterministic and test-covered.