### PR TITLE
Improve route validation and lazy controller setup

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -1,7 +1,40 @@
-from flask import *
+from flask import Blueprint, g, jsonify, render_template, request
 from controllers.NewsController import NewsController
+
 routes = Blueprint("routes", __name__)
-news_controller = NewsController("mistralai") # default model name
+news_controller = None
+
+
+def _build_controller(llm_name):
+    try:
+        return NewsController(llm_name)
+    except ValueError:
+        return None
+
+
+def _default_controller():
+    global news_controller
+    if news_controller is None:
+        news_controller = NewsController("mistralai")
+    return news_controller
+
+
+def _invalid_model_response(llm_name):
+    return (
+        jsonify(
+            {
+                "error": f"Unsupported llm_name: {llm_name}",
+                "supported_models": ["llama", "gemma", "mistralai"],
+            }
+        ),
+        400,
+    )
+
+
+def _extract_keyword():
+    user_keywords = [keyword.strip() for keyword in request.args.getlist("keywords")]
+    user_keywords = [keyword for keyword in user_keywords if keyword]
+    return user_keywords[0] if user_keywords else None
 
 """
 home page route
@@ -18,7 +51,9 @@ set route for different LLM models
 def set_llm_route(llm_name):
     if llm_name == "favicon.ico":
         return "", 204  # No Content response for favicon requests
-    g.news_controller = NewsController(llm_name)
+    g.news_controller = _build_controller(llm_name)
+    if g.news_controller is None:
+        return _invalid_model_response(llm_name)
     return render_template("llm.html", llm_name=llm_name)
 
 
@@ -27,7 +62,9 @@ return news without considering keywords
 """
 @routes.route("/<llm_name>/news", methods=["GET"])
 def getNews_route(llm_name):
-    g.news_controller = NewsController(llm_name)
+    g.news_controller = _build_controller(llm_name)
+    if g.news_controller is None:
+        return _invalid_model_response(llm_name)
     news = g.news_controller.getNews()
     return render_template("news.html", data=news)
 
@@ -37,11 +74,16 @@ return news based on certain keywords
 """
 @routes.route("/<llm_name>/news_keywords", methods=["GET"])
 def getNewsWithKeywords_route(llm_name):
-    # get list of keywords as argument from User's request
-    g.news_controller = NewsController(llm_name)
-    user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
-    return render_template("news_key.html", data=data,keyword=user_keywords[0])
+    g.news_controller = _build_controller(llm_name)
+    if g.news_controller is None:
+        return _invalid_model_response(llm_name)
+
+    keyword = _extract_keyword()
+    if not keyword:
+        return jsonify({"error": "Missing required query parameter: keywords"}), 400
+
+    data = g.news_controller.getNewsWithKeywords(keyword)
+    return render_template("news_key.html", data=data, keyword=keyword)
 
 
 """
@@ -49,4 +91,10 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    controller = getattr(g, "news_controller", None)
+    if controller is None:
+        try:
+            controller = _default_controller()
+        except Exception:
+            return jsonify({"error": "Route not found"}), 404
+    return controller.notFound(error)


### PR DESCRIPTION
## Summary`n- make default controller initialization lazy to reduce startup fragility`n- return clear 400 errors for unsupported `llm_name` values`n- validate and sanitize `keywords` query input before calling service methods`n- make 404 handling resilient when request-local controller state is missing`n`n## Why`nThis hardens route behavior and prevents common runtime errors from invalid user input or context state.