### PR TITLE
docs: Update local setup instructions for Python and Pinecone

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Once a user requests our API, it retrieves news data from our knowledge base and
 | ![Home Page](assets/home.png) | ![LLM Page](assets/llm.png) | ![News Page](assets/news.png) | ![News Keywords Page](assets/news_keywords.png) |
 
 ## Setup
+### Dependency Notes
+* This project requires Python 3.11 for ML library compatibility.
+* If you encounter wheel building errors during pip install, try using these commands
+`py -3.11 -m venv venv`
+`venv\Scripts\activate`
+`pip install -r requirements.txt --prefer-binary`
+
 1. Install all necessary packages
 
 `pip install -r ./requirements.txt`
@@ -29,7 +36,14 @@ Once a user requests our API, it retrieves news data from our knowledge base and
 ```
 https://www.pinecone.io/
 ```
-Login to Pinecone and create a new index with the name `news-index`. Then, add the Pinecone API key in the `.env` file.
+Login to Pinecone and create a new index with the name `cybernews-hybrid-test-2`. Then, add the Pinecone API key in the `.env` file.
+### Pinecone Configuration
+When creating your Pinecone API token and index, you must use the following exact settings for the hybrid search to function properly:
+* Index name: cybernews-hybrid-test-2
+* Dimensions: 384
+* Metric: dotproduct (Note: Do not use cosine)
+* Capacity mode: Serverless
+* Cloud / Region: AWS / us-east-1
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the README.md setup instructions to explicitly state the requirement for Python 3.11 to ensure ML library compatibility. Additionally, added the exact Pinecone index configuration (Index name, Dimensions, Metric, Capacity mode, and Cloud/Region) required for the hybrid search functionality to authenticate and work locally.

## Related Issue
Resolves #142 

## Motivation and Context
Building the environment with Python 3.12+ causes wheel-building failures for underlying packages like Numpy. Furthermore, omitting the exact Pinecone settings causes the backend vector search to fail silently or crash. Documenting these prevents setup fatigue for future developers.

## How Has This Been Tested?
I tested these exact configurations locally on Windows.

1.Created a fresh venv strictly using Python 3.11.
2.Ran pip install -r requirements.txt resulting in successful builds.
3.Configured the Pinecone index precisely as documented (cybernews-hybrid-test-2, 384 dimensions, dotproduct).
4.Booted the Flask server and verified that the backend connected without errors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
