### PR TITLE
index based article selection and prompt update

### DIFF
--- a/prompts/withkey.json
+++ b/prompts/withkey.json
@@ -1,7 +1,7 @@
 [
     {
         "role": "system",
-        "content": "You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+        "content": "You are a cybersecurity news curator. You will receive a numbered list of article headlines. Your job is to select the best articles matching a given keyword and return ONLY their index numbers."
     },
     {
         "role": "user",
@@ -9,7 +9,7 @@
     },
     {
         "role": "assistant",
-        "content": "I have read the news you provided. Now please give me your keywords."
+        "content": "I have read the numbered article list. Now please give me your keywords."
     },
     {
         "role": "user",
@@ -17,10 +17,10 @@
     },
     {
         "role": "assistant",
-        "content": "I have read the keywords you provided. Now please tell me how you want me to generate the answers."
+        "content": "I have noted the keywords. Please tell me your selection criteria."
     },
     {
         "role": "user",
-        "content": "Please give me a list of the most recent cybersecurity news based on the news and keyword given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news. Return the news strictly in the required format. do not leave any key empty. if you do not have information, make up some."
+        "content": "Select the {news_number} most relevant and recent cybersecurity news articles from the list above that relate to the given keywords.\n\nSelection rules:\n- ONLY select genuine news articles reporting on real cybersecurity events, incidents, vulnerabilities, breaches, or policy changes.\n- Prioritize articles that are most relevant to the provided keywords.\n- EXCLUDE the following: webinar invitations, marketing or promotional content, product/tool announcements that are not news, Reddit self-posts or discussion threads, sponsored content, job postings, opinion pieces without a news event, and generic advisories without a specific incident.\n\nReturn ONLY the index numbers of your selected articles as a comma-separated list. Example output: 1, 4, 7, 12\n\nDo not include any other text, explanation, or formatting. Only output the comma-separated index numbers."
     }
 ]

--- a/prompts/withoutkey.json
+++ b/prompts/withoutkey.json
@@ -1,7 +1,7 @@
 [
     {
         "role": "system",
-        "content": "You are a news analyzer that will read the given cyber security news and return the answer based on the user's requirement."
+        "content": "You are a cybersecurity news curator. You will receive a numbered list of article headlines. Your job is to select the best articles and return ONLY their index numbers."
     },
     {
         "role": "user",
@@ -9,10 +9,10 @@
     },
     {
         "role": "assistant",
-        "content": "I have read the news you provided. Now please tell me your request."
+        "content": "I have read the numbered article list. Please tell me your selection criteria."
     },
     {
         "role": "user",
-        "content": "Please give me a list of the most recent cybersecurity news based on the news given above. Indicate the source and date. Each news should be strictly in the format of {news_format}. Your reply should be news-only, without adding any of your conversational content. Do not use bullet points OR number list. Do not use regex. Only give the output in the required format. Do not stop generating the answer until it is complete. Return at most {news_number} news."
+        "content": "Select the {news_number} most relevant and recent cybersecurity news articles from the list above.\n\nSelection rules:\n- ONLY select genuine news articles reporting on real cybersecurity events, incidents, vulnerabilities, breaches, or policy changes.\n- EXCLUDE the following: webinar invitations, marketing or promotional content, product/tool announcements that are not news, Reddit self-posts or discussion threads, sponsored content, job postings, opinion pieces without a news event, and generic advisories without a specific incident.\n\nReturn ONLY the index numbers of your selected articles as a comma-separated list. Example output: 1, 4, 7, 12\n\nDo not include any other text, explanation, or formatting. Only output the comma-separated index numbers."
     }
 ]

--- a/services/NewsService.py
+++ b/services/NewsService.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 from dotenv import dotenv_values
 from flask import jsonify
@@ -29,7 +30,6 @@ class NewsService:
             self.llm = HuggingFaceEndpoint(
                 repo_id=repo_id, temperature=0.5, token=HUGGINGFACEHUB_API_TOKEN
             )
-        self.news_format = "[title, source, date(DD/MM/YYYY), news url];"
         self.news_number = 10
 
     """
@@ -60,6 +60,18 @@ class NewsService:
             
         news_data = news_data[:50] # limit the number of news to 50 , as LLMs have a context limit
 
+        # Build a numbered article list for the LLM (URLs are NOT sent)
+        numbered_list_lines = []
+        article_metadata = {}  # index -> full metadata dict
+        for i, doc in enumerate(news_data, start=1):
+            headline = doc.get('headlines', 'N/A')
+            source = doc.get('author', 'N/A')
+            date = doc.get('newsDate', 'N/A')
+            numbered_list_lines.append(f"[{i}] {headline} — {source} — {date}")
+            article_metadata[i] = doc
+
+        numbered_list_str = "\n".join(numbered_list_lines)
+
         template = """Question: {question}
         Answer: Let's think step by step."""
 
@@ -77,11 +89,9 @@ class NewsService:
         # Replace placeholders in the messages
         for message in messages:
             if message['role'] == 'user' and '<news_data_placeholder>' in message['content']:
-                message['content'] = message['content'].replace('<news_data_placeholder>', str(news_data))
+                message['content'] = message['content'].replace('<news_data_placeholder>', numbered_list_str)
             if user_keywords and message['role'] == 'user' and '<user_keywords_placeholder>' in message['content']:
                 message['content'] = message['content'].replace('<user_keywords_placeholder>', str(user_keywords))
-            if message['role'] == 'user' and '{news_format}' in message['content']:
-                message['content'] = message['content'].replace('{news_format}', self.news_format)
             if message['role'] == 'user' and '{news_number}' in message['content']:
                 message['content'] = message['content'].replace('{news_number}', str(self.news_number))
 
@@ -89,8 +99,8 @@ class NewsService:
         llm_chain = LLMChain(prompt=prompt, llm=self.llm)
         output = llm_chain.invoke(messages)
 
-        # Convert news data into JSON format
-        news_JSON = self.toJSON(output['text'])
+        # Resolve selected indices back to full article metadata
+        news_JSON = self.resolve_indices(output['text'], article_metadata)
   
         return news_JSON
 
@@ -112,43 +122,32 @@ class NewsService:
         return data
 
     """
-    Convert news given by Huggingface endpoint API into JSON format.
+    Parse the LLM output for selected article indices and resolve them
+    to full article metadata. URLs are never taken from LLM output.
     """
 
-    def toJSON(self, data: str):
-        if len(data) == 0:
-            return {}
-        news_list = data.split("\n")
+    @staticmethod
+    def resolve_indices(llm_output: str, article_metadata: dict):
+        if not llm_output or len(llm_output.strip()) == 0:
+            return []
+
+        # Extract all integers from the LLM output
+        raw_indices = re.findall(r'\d+', llm_output)
+
+        seen = set()
         news_list_json = []
-        news_list.pop(0)
-        for item in news_list:
-            # Avoid dirty data
-            if len(item) == 0:
+        for idx_str in raw_indices:
+            idx = int(idx_str)
+            if idx in seen or idx not in article_metadata:
                 continue
-            # Remove leading and trailing square brackets and split by comma and strip extra spaces
-            data_list = [item.strip().strip('"') for item in item.strip('[').strip(']').split(',')]
-            data_list = [val.strip() for val in data_list]
-
-            for i in data_list:
-                print(i)
-                print("----")
-                
-            print(data_list)
-            # Assign default values for missing elements
-            start_index = data_list[0].find('[') if len(data_list) > 0 else -1
-            end_index = data_list[3].find(']') if len(data_list) > 3 else -1
-            title = data_list[0][start_index+1:] if len(data_list) > 0 else "No title provided"
-            source = data_list[1] if len(data_list) > 1 else "No source provided"
-            date = data_list[2] if len(data_list) > 2 else "No date provided"
-            url = data_list[3][:end_index-1] if len(data_list) > 3 else "No URL provided"
-
+            seen.add(idx)
+            doc = article_metadata[idx]
             news_item = {
-                "title": title,
-                "source": source,
-                "date": date,
-                "url": url,
+                "title": doc.get('headlines', 'No title provided'),
+                "source": doc.get('author', 'No source provided'),
+                "date": doc.get('newsDate', 'No date provided'),
+                "url": doc.get('newsURL', 'No URL provided'),
             }
             news_list_json.append(news_item)
 
-        news_list_json.pop()
         return news_list_json


### PR DESCRIPTION
Fixes #114

### Description

The LLM was previously asked to embed URLs in its text output (`[title, source, date, url]`), which a fragile comma-split parser then extracted. This PR switches to **index-based article selection** the LLM receives only numbered headlines and returns selected indices, while URLs are resolved from the original Pinecone metadata in code.

### Changes Made

- **`services/NewsService.py`**: Send numbered headline list (no URLs) to LLM; replace `toJSON()` with `resolve_indices()` static method; remove `news_format`
- **`prompts/withkey.json`**: Rewrite to index-based output; add content filtering rules (exclude webinars, promos, Reddit self-posts, etc.)
- **`prompts/withoutkey.json`**: Same prompt rewrite, minus keyword context

### Why This Helps

- **Eliminates URL hallucination**: URLs never pass through the LLM
- **Fixes parser breakage**: no more comma-split failures on URLs containing commas
- **Saves context tokens**: long URLs are no longer sent to or returned by the LLM
- **Better content quality**: prompts now explicitly exclude non-news content (webinars, promos, tool announcements, sponsored content)

### Verification
- Verified by running full pipeline, and verified the links working
- Non-LLM raw routes (`/raw/news`, `/raw/news_keywords`) remain unchanged
- Return format (`[{title, source, date, url}, ...]`) is identical, no breaking changes to consumers

### Checklist

- [x] `toJSON()` replaced with index-based `resolve_indices()`
- [x] URLs resolved from original metadata, never from LLM output
- [x] Unit tests passing
- [x] Non-LLM path unaffected
- [x] No breaking changes to API response format
