### PR TITLE
fix: dotenv and pinecone index name

### DIFF
--- a/db_update/Update.py
+++ b/db_update/Update.py
@@ -1,16 +1,18 @@
 import sys
 import os
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 from pinecone import Pinecone, ServerlessSpec
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+load_dotenv()
+
 from cybernews.CyberNews import CyberNews
 
-PINECONE_API = dotenv_values(".env").get("PINECONE_API_KEY")
+PINECONE_API = os.getenv("PINECONE_API_KEY")
 
 # Configure client
 pc = Pinecone(api_key=PINECONE_API)
-index_name = str.lower(dotenv_values(".env").get("PINECONE_INDEX_NAME")) # pinecone index name must be in lowercase
+index_name = os.getenv("PINECONE_INDEX_NAME").lower() 
 
 
 

--- a/models/NewsModel.py
+++ b/models/NewsModel.py
@@ -1,11 +1,20 @@
 from config.Database import client
 from datetime import datetime
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 class CybernewsDB:
     def __init__(self):
         from sentence_transformers import SentenceTransformer, SparseEncoder
         self.client = client
-        self.index_name = "cybernews-hybrid-test-2"
+        
+        index_name = os.getenv("PINECONE_INDEX_NAME")
+        if not index_name:
+            raise ValueError("PINECONE_INDEX_NAME environment variable is missing in .env")
+            
+        self.index_name = index_name.lower()
         self.namespace = "c2si" 
         self.index = self.client.Index(self.index_name)
         


### PR DESCRIPTION
Fixes #146 

- **Loaded [.env](cci:7://file:///c:/Users/Anvay/Desktop/b0bot/.env:0:0-0:0) globally**: Added `load_dotenv()` to [db_update/Update.py](cci:7://file:///c:/Users/Anvay/Desktop/b0bot/db_update/Update.py:0:0-0:0) so variables are loaded into `os.environ`.
- **Removed hardcoded Pinecone index**: Replaced the hardcoded `"cybernews-hybrid-test-2"` index name in [models/NewsModel.py](cci:7://file:///c:/Users/Anvay/Desktop/b0bot/models/NewsModel.py:0:0-0:0). The Pinecone index name is now strictly read directly from `os.getenv("PINECONE_INDEX_NAME")` across the application. Added a safeguard to throw a `ValueError` if the user forgets to set it in their [.env]
