### PR TITLE
fix: add route validation and proper 404 handler response

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -1,7 +1,11 @@
 from flask import *
 from controllers.NewsController import NewsController
+import json
+
 routes = Blueprint("routes", __name__)
-# news_controller = NewsController("mistralai") # default model name
+
+with open('config/llm_config.json') as f:
+    VALID_LLMS = set(json.load(f).keys())
 
 """
 home page route
@@ -17,7 +21,9 @@ set route for different LLM models
 @routes.route("/<llm_name>", methods=["GET"])
 def set_llm_route(llm_name):
     if llm_name == "favicon.ico":
-        return "", 204  # No Content response for favicon requests
+        return "", 204
+    if llm_name not in VALID_LLMS:
+        return jsonify({"error": f"Unsupported model '{llm_name}'. Valid options: {', '.join(VALID_LLMS)}"}), 400
     g.news_controller = NewsController(llm_name)
     return render_template("llm.html", llm_name=llm_name)
 
@@ -27,6 +33,8 @@ return news without considering keywords
 """
 @routes.route("/<llm_name>/news", methods=["GET"])
 def getNews_route(llm_name):
+    if llm_name not in VALID_LLMS:
+        return jsonify({"error": f"Unsupported model '{llm_name}'. Valid options: {', '.join(VALID_LLMS)}"}), 400
     g.news_controller = NewsController(llm_name)
     news = g.news_controller.getNews()
     return render_template("news.html", data=news)
@@ -37,10 +45,13 @@ return news based on certain keywords
 """
 @routes.route("/<llm_name>/news_keywords", methods=["GET"])
 def getNewsWithKeywords_route(llm_name):
-    # get list of keywords as argument from User's request
-    g.news_controller = NewsController(llm_name)
+    if llm_name not in VALID_LLMS:
+        return jsonify({"error": f"Unsupported model '{llm_name}'. Valid options: {', '.join(VALID_LLMS)}"}), 400
     user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
+    if not user_keywords or not user_keywords[0].strip():
+        return jsonify({"error": "Keywords parameter is required"}), 400
+    g.news_controller = NewsController(llm_name)
+    data = g.news_controller.getNewsWithKeywords(user_keywords[0].strip())
     return render_template("news_key.html", data=data, keyword=user_keywords[0])
 
 
@@ -49,7 +60,6 @@ return news without considering keywords (NO LLM)
 """
 @routes.route("/raw/news", methods=["GET"])
 def getNews_raw_route():
-    # Instantiate without a model to bypass LLM initialization entirely
     g.news_controller = NewsController(None)
     news = g.news_controller.getNews()
     return render_template("news.html", data=news, llm_name="raw")
@@ -60,10 +70,11 @@ return news based on certain keywords (NO LLM)
 """
 @routes.route("/raw/news_keywords", methods=["GET"])
 def getNewsWithKeywords_raw_route():
-    # Instantiate without a model to bypass LLM initialization entirely
-    g.news_controller = NewsController(None)
     user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
+    if not user_keywords or not user_keywords[0].strip():
+        return jsonify({"error": "Keywords parameter is required"}), 400
+    g.news_controller = NewsController(None)
+    data = g.news_controller.getNewsWithKeywords(user_keywords[0].strip())
     return render_template("news_key.html", data=data, keyword=user_keywords[0], llm_name="raw")
 
 
@@ -72,4 +83,7 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    if hasattr(g, 'news_controller') and g.news_controller is not None:
+        return g.news_controller.notFound(error)
+    default_controller = NewsController("mistralai")
+    return default_controller.notFound(error)


### PR DESCRIPTION
## Description

This PR improves route handling with proper validation and fixes the 404 handler response path.

### Changes:

1. **LLM Model Validation**: Validate model names against `config/llm_config.json` and return 400 error with valid options for unsupported models
2. **Keywords Parameter Validation**: Ensure keywords parameter is provided and non-empty before processing
3. **404 Handler Fix**: Properly return the response and use fallback controller when request-local controller is unavailable

### Related Issues
- Closes #116
- Closes #125

## Motivation and Context

The previous implementation would create controllers for any LLM name without validation, leading to confusing errors. The 404 handler didn't return its response, causing empty responses.

## How Has This Been Tested

- Syntax verification passed
- Changes are minimal and focused on validation logic

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** document