### PR TITLE
fix: remove hardcoded keywords= suffix from form action

### DIFF
--- a/static/js/content.js
+++ b/static/js/content.js
@@ -5,19 +5,19 @@ function renderContent(baseLLM) {
             title: "Welcome to b0bot!",
             subtitle: "You are now using Gemma-2b as your base LLM",
             newsPath: "/gemma/news",
-            newsKeywordsPath: "/gemma/news_keywords?keywords="
+            newsKeywordsPath: "/gemma/news_keywords"
         },
         llama: {
             title: "Welcome to b0bot!",
             subtitle: "You are now using Llama-3 as your base LLM",
             newsPath: "/llama/news",
-            newsKeywordsPath: "/llama/news_keywords?keywords="
+            newsKeywordsPath: "/llama/news_keywords"
         },
         mistralai: {
             title: "Welcome to b0bot!",
             subtitle: "You are now using MistralAI as your base LLM",
             newsPath: "/mistralai/news",
-            newsKeywordsPath: "/mistralai/news_keywords?keywords="
+            newsKeywordsPath: "/mistralai/news_keywords"
         }
     };
 


### PR DESCRIPTION
## Description

Remove hardcoded `?keywords=` suffix from form action URLs in `content.js`. The form now submits exactly one `keywords` parameter from user input.

### Related Issues
- Closes #117

## Motivation and Context

The previous form actions had `?keywords=` hardcoded which could cause empty leading keyword values when submitted.

## How Has This Been Tested

- JavaScript syntax verification passed
- Changes are minimal (3 lines changed)

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** document