### PR TITLE
fix: safe access to href attribute in news extractor

### DIFF
--- a/cybernews/extractor.py
+++ b/cybernews/extractor.py
@@ -119,7 +119,7 @@ class Extractor(Performance):
             if self._check_ad(news_date):
                 continue
 
-            if index >= len(news_url) or not self.valid_url_check(news_url[index]["href"]):
+            if index >= len(news_url) or not news_url[index].get("href") or not self.valid_url_check(news_url[index].get("href", "")):
                 continue
 
             full_news_text = news_full_news[index].text.strip() if index < len(news_full_news) else ""


### PR DESCRIPTION
## Description

Use `.get()` to safely access href attribute, preventing KeyError when href is missing from link elements.

### Related Issues
- Closes #120

## Motivation and Context

Some news sources may not have href attributes on all link elements. This change prevents crashes on such cases.

## How Has This Been Tested

- Syntax verification passed
- Minimal change (1 line)

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** document