### PR TITLE
fix: use newsDate for chronological ordering instead of mutable id

### DIFF
--- a/cybernews/sorting.py
+++ b/cybernews/sorting.py
@@ -68,7 +68,7 @@ class Sorting:
 
     def ordering_news(self, news):
         data = sorted(
-            news, key=lambda individual_news: individual_news["id"], reverse=True
+            news, key=lambda individual_news: self.ordering_date(individual_news.get("newsDate", "N/A")), reverse=True
         )
 
         data = self._ordering_id(data)


### PR DESCRIPTION
## Description

Sort news by actual date (newsDate field) instead of id field, which was being overwritten with UUIDs after sorting.

### Related Issues
- Closes #124

## Motivation and Context

The previous implementation sorted by `id` field, but `_ordering_id()` immediately overwrites all ids with UUIDs, making the sort meaningless.

## How Has This Been Tested

- Syntax verification passed
- All changes are non-breaking

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** document