### PR TITLE
Improve backend stability in NewsService and NewsRoutes

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -40,6 +40,8 @@ def getNewsWithKeywords_route(llm_name):
     # get list of keywords as argument from User's request
     g.news_controller = NewsController(llm_name)
     user_keywords = request.args.getlist("keywords")
+    if not user_keywords:
+        return "Missing 'keywords' parameter", 400
     data = g.news_controller.getNewsWithKeywords(user_keywords[0])
     return render_template("news_key.html", data=data, keyword=user_keywords[0])
 
@@ -63,6 +65,8 @@ def getNewsWithKeywords_raw_route():
     # Instantiate without a model to bypass LLM initialization entirely
     g.news_controller = NewsController(None)
     user_keywords = request.args.getlist("keywords")
+    if not user_keywords:
+        return "Missing 'keywords' parameter", 400
     data = g.news_controller.getNewsWithKeywords(user_keywords[0])
     return render_template("news_key.html", data=data, keyword=user_keywords[0], llm_name="raw")
 
@@ -72,4 +76,4 @@ deal requests with wrong route
 """
 @routes.errorhandler(404)
 def notFound_route(error):
-    g.news_controller.notFound(error)
+    return g.news_controller.notFound(error)

--- a/services/NewsService.py
+++ b/services/NewsService.py
@@ -116,14 +116,18 @@ class NewsService:
     """
 
     def toJSON(self, data: str):
-        if len(data) == 0:
-            return {}
+        if not data or len(data.strip()) == 0:
+            return []
+        
         news_list = data.split("\n")
         news_list_json = []
-        news_list.pop(0)
+        
+        if len(news_list) > 0:
+            news_list.pop(0) # Removing the introductory text from LLM
+            
         for item in news_list:
             # Avoid dirty data
-            if len(item) == 0:
+            if len(item.strip()) == 0:
                 continue
             # Remove leading and trailing square brackets and split by comma and strip extra spaces
             data_list = [item.strip().strip('"') for item in item.strip('[').strip(']').split(',')]
@@ -150,5 +154,7 @@ class NewsService:
             }
             news_list_json.append(news_item)
 
-        news_list_json.pop()
+        if news_list_json:
+            news_list_json.pop() # Removing the concluding text from LLM if any
+            
         return news_list_json


### PR DESCRIPTION
Fixes #161
Hello, here are some explained issues that i have found while reading the repository as well as some proposals to fix it :

### 1. Hardened LLM Response Parsing
Path: services/NewsService.py

- Initial Problem / Bug: The toJSON method assumed the text returned by the LLM would always be perfectly formatted and non-empty. It unconditionally executed .pop(0) and .pop() on the split string arrays to remove the LLM's introductory and concluding remarks. If the LLM returned an empty string or just whitespace, the arrays would be empty, causing the application to crash immediately upon trying to pop elements.
- Proposed solution: It introduces defensive boundary checks before manipulating the arrays. It verifies that the data string actually contains characters(via .strip()) , checks if len(news_list) > 0 before the first pop, and checks if news_list_json before the final pop.
- What it prevents: It prevents IndexError: pop from empty list crashes, allowing the backend to gracefully return an empty JSON array to the frontend if the LLM endpoint fails to generate proper text.

### 2. Safeguarded API Keyword Arguments
Path: routes/NewsRoutes.py

- Initial Problem / Bug: The endpoints extracted the keywords argument using request.args.getlist("keywords") and immediately accessed the first element using user_keywords[0]. If a user made a generic GET request without appending the ?keywords= parameter to the URL, the list would be empty.
- Proposed solution : It adds a validation check (if not user_keywords:) right after extracting the arguments. If the list is empty, it returns a descriptive error message and an HTTP 400 Bad Request status code.
- What it prevents: It prevents runtime IndexError: list index out of range errors. Instead of the server throwing a 500 error trace and crashing the worker, it now formally rejects malformed requests appropriately.

### 3. Fixed 404 Error Handler Response
Path: routes/NewsRoutes.py

- Initial Problem / Bug: The @routes.errorhandler(404) block invoked the correct controller method g.news_controller.notFound(error) , but , lacked a return statement. Because Python functions implicitly return None if no return is specified, the router was passing None back to the Flask application.
- Proposed solution : It prepends the return keyword to the controller method call, ensuring the generated HTML response tuple is actually handed back to the framework.
- What it prevents: It prevents secondary TypeError: The view function did not return a valid response exceptions during 404 events. Before this fix, even standard "Page Not Found" errors would trigger server-level crashes
