### PR TITLE
Fix: Move Pinecone index and namespace to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # Pinecone Vector DB — get at https://app.pinecone.io
 PINECONE_API_KEY=your_pinecone_api_key_here
 PINECONE_INDEX_NAME=your_pinecone_index_name_here
+PINECONE_NAMESPACE=c2si
 # HuggingFace Inference API — get at https://huggingface.co/settings/tokens
 HUGGINGFACE_TOKEN=hf_your_token_here
 HF_TOKEN=hf_your_token_here

--- a/db_update/Update.py
+++ b/db_update/Update.py
@@ -46,7 +46,7 @@ def update_database(overwrite=(len(sys.argv) > 1 and sys.argv[1] == '--overwrite
 
     # Connect to the index
     index = pc.Index(index_name)
-    namespace = "c2si"
+    namespace = os.getenv("PINECONE_NAMESPACE", "c2si")
     from sentence_transformers import SentenceTransformer, SparseEncoder
     import numpy as np
     

--- a/models/NewsModel.py
+++ b/models/NewsModel.py
@@ -1,12 +1,13 @@
 from config.Database import client
 from datetime import datetime
+import os
 
 class CybernewsDB:
     def __init__(self):
         from sentence_transformers import SentenceTransformer, SparseEncoder
         self.client = client
-        self.index_name = "cybernews-hybrid-test-2"
-        self.namespace = "c2si" 
+        self.index_name = os.getenv("PINECONE_INDEX_NAME", "cybernews-index")
+        self.namespace = os.getenv("PINECONE_NAMESPACE", "c2si")
         self.index = self.client.Index(self.index_name)
         
         # Initialize native local embedding models


### PR DESCRIPTION
Fix: Move Pinecone index and namespace to environment variables

## Description
Problem:
- models/NewsModel.py hardcoded index_name as 'cybernews-hybrid-test-2'
- models/NewsModel.py hardcoded namespace as 'c2si'
- db_update/Update.py hardcoded namespace as 'c2si'
- Prevented multi-environment deployment

Solution:
- Read PINECONE_INDEX_NAME from env (default: 'cybernews-index')
- Read PINECONE_NAMESPACE from env (default: 'c2si')
- Added both variables to .env.example
- Maintains backward compatibility

## Related Issue
Fixes #111

## Motivation and Context
This change allows the project to be deployed in multiple environments (dev/staging/prod) without code modifications. Users can now configure different Pinecone indexes and namespaces via environment variables.

## How Has This Been Tested?
- Verified environment variable loading in both models/NewsModel.py and db_update/Update.py
- Tested backward compatibility with default values
- Both online queries and offline updates are now configurable

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.