### PR TITLE
feat: add multi-turn conversation support

### DIFF
--- a/chat_routes.py
+++ b/chat_routes.py
@@ -1,0 +1,63 @@
+"""
+Flask routes for the multi-turn chat feature.
+Register this blueprint in app.py to enable /chat endpoints.
+"""
+
+from flask import Blueprint, request, jsonify
+from conversation import conversation_manager
+
+chat_bp = Blueprint("chat", __name__)
+
+
+@chat_bp.route("/<llm_name>/chat", methods=["POST"])
+def chat(llm_name):
+    """
+    POST JSON with {"message": "your question", "session_id": "optional"}
+    Returns {"session_id": "...", "response": "...", "turn_count": N}
+
+    First call: don't pass session_id, you'll get one back.
+    Follow-up calls: pass the session_id to continue the conversation.
+    """
+    data = request.get_json()
+    if not data or "message" not in data:
+        return jsonify({"error": "Need a 'message' field in JSON body"}), 400
+
+    user_msg = data["message"]
+    sid = data.get("session_id")
+
+    sid = conversation_manager.get_or_create_session(sid)
+
+    # load the right LLM - reusing whatever b0bot already has
+    try:
+        from controllers.llm_controller import load_llm
+        llm = load_llm(llm_name)
+    except (ImportError, Exception) as e:
+        return jsonify({
+            "error": f"Couldn't load LLM '{llm_name}': {str(e)}. "
+                     f"Try: llama, gemma, or mistralai"
+        }), 400
+
+    # try to pull relevant news as context
+    news_ctx = ""
+    try:
+        from services.news_service import get_recent_news
+        news_ctx = get_recent_news(keywords=user_msg)
+    except Exception:
+        pass  # no news context is fine, chat still works
+
+    result = conversation_manager.chat(sid, llm, user_msg, news_ctx)
+    return jsonify(result)
+
+
+@chat_bp.route("/chat/history/<session_id>", methods=["GET"])
+def get_history(session_id):
+    """Get the conversation history for a session."""
+    history = conversation_manager.get_history(session_id)
+    return jsonify({"session_id": session_id, "history": history})
+
+
+@chat_bp.route("/chat/clear/<session_id>", methods=["POST"])
+def clear_history(session_id):
+    """Clear chat history for a session (keeps session alive)."""
+    ok = conversation_manager.clear_session(session_id)
+    return jsonify({"session_id": session_id, "cleared": ok})

--- a/conversation.py
+++ b/conversation.py
@@ -1,0 +1,102 @@
+"""
+Multi-turn conversation support for B0Bot.
+
+Adds conversation memory so users can have back-and-forth
+discussions about cybersecurity news instead of one-off queries.
+"""
+
+from langchain.memory import ConversationBufferWindowMemory
+from langchain.chains import ConversationChain
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+import uuid
+
+
+class ConversationManager:
+    """Handles multi-turn conversations with per-session memory."""
+
+    def __init__(self, max_history=10):
+        self.conversations = {}
+        self.max_history = max_history
+
+    def create_session(self):
+        """Start a new chat session, returns its id."""
+        sid = str(uuid.uuid4())
+        self.conversations[sid] = ConversationBufferWindowMemory(
+            k=self.max_history,
+            return_messages=True,
+            memory_key="chat_history",
+        )
+        return sid
+
+    def get_or_create_session(self, session_id=None):
+        """Return existing session or make a new one if missing."""
+        if session_id and session_id in self.conversations:
+            return session_id
+        return self.create_session()
+
+    def chat(self, session_id, llm, user_message, news_context=""):
+        """Main method - send a message, get response with memory of past turns."""
+        if session_id not in self.conversations:
+            session_id = self.create_session()
+
+        memory = self.conversations[session_id]
+
+        # build system prompt - keeping it simple
+        sys_prompt = (
+            "You are B0Bot, a cybersecurity news assistant. "
+            "Help users understand the latest threats, vulnerabilities, "
+            "and security news. Keep answers concise and useful."
+        )
+        if news_context:
+            sys_prompt += f"\n\nRecent news for context:\n{news_context}"
+
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", sys_prompt),
+            MessagesPlaceholder(variable_name="chat_history"),
+            ("human", "{input}"),
+        ])
+
+        chain = ConversationChain(
+            llm=llm,
+            memory=memory,
+            prompt=prompt,
+            input_key="input",
+            verbose=False,
+        )
+        result = chain.invoke({"input": user_message})
+
+        return {
+            "session_id": session_id,
+            "response": result.get("response", str(result)),
+            "turn_count": len(memory.chat_memory.messages) // 2,
+        }
+
+    def get_history(self, session_id):
+        """Get full chat history for a session."""
+        if session_id not in self.conversations:
+            return []
+
+        msgs = self.conversations[session_id].chat_memory.messages
+        return [
+            {"role": "user" if m.type == "human" else "assistant",
+             "content": m.content}
+            for m in msgs
+        ]
+
+    def clear_session(self, session_id):
+        """Wipe chat history but keep session alive."""
+        if session_id in self.conversations:
+            self.conversations[session_id].clear()
+            return True
+        return False
+
+    def delete_session(self, session_id):
+        """Remove a session entirely."""
+        if session_id in self.conversations:
+            del self.conversations[session_id]
+            return True
+        return False
+
+
+# single instance, imported by routes
+conversation_manager = ConversationManager()


### PR DESCRIPTION
## Description
Adds multi-turn conversation support to B0Bot using LangChain's ConversationBufferWindowMemory. Users can now have back-and-forth discussions about cybersecurity news instead of single-shot queries.

Two new files:
- conversation.py: ConversationManager class with per-session chat memory
- chat_routes.py: Flask blueprint with /chat, /history, /clear endpoints

How it works:
- First POST to /<llm_name>/chat returns a session_id
- Pass that session_id in follow-up messages to continue the conversation
- LLM remembers the last 10 turns of context
- News context is automatically pulled from the existing knowledge base

## Related Issue
This implements the "multi-turn dialogue" feature listed in the GSoC 2026 expected results for B0Bot.

## Motivation and Context
Currently B0Bot only supports single-shot queries. Users asking follow-up questions lose all context from previous interactions. This change adds conversation memory so the LLM can give contextual responses across multiple turns.

## How Has This Been Tested?
Manual testing of ConversationManager class methods (create_session, chat, get_history, clear_session). Integration testing planned after mentor feedback on the approach.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.