### PR TITLE
sanitise keywords query param to prevent IndexError crash and abuse (#140)

### DIFF
--- a/routes/NewsRoutes.py
+++ b/routes/NewsRoutes.py
@@ -1,7 +1,41 @@
 from flask import *
 from controllers.NewsController import NewsController
 routes = Blueprint("routes", __name__)
-# news_controller = NewsController("mistralai") # default model name
+
+MAX_KEYWORD_LENGTH = 200
+
+
+def _validate_keyword(raw_list):
+    """
+    Validates the ?keywords= query parameter.
+
+    Returns (keyword, error_response):
+      - On success: (stripped_keyword, None)
+      - On failure: (None, (json_response, status_code))
+
+    Checks performed:
+      1. Parameter must be present.
+      2. Value must be non-empty after stripping whitespace.
+      3. Value must not exceed MAX_KEYWORD_LENGTH characters.
+    """
+    if not raw_list:
+        return None, (jsonify({"error": "Missing required query parameter: keywords"}), 400)
+
+    keyword = raw_list[0].strip()
+
+    if not keyword:
+        return None, (jsonify({"error": "keywords parameter cannot be empty"}), 400)
+
+    if len(keyword) > MAX_KEYWORD_LENGTH:
+        return None, (
+            jsonify({
+                "error": f"keywords parameter exceeds maximum length of {MAX_KEYWORD_LENGTH} characters"
+            }),
+            400,
+        )
+
+    return keyword, None
+
 
 """
 home page route
@@ -37,11 +71,13 @@ return news based on certain keywords
 """
 @routes.route("/<llm_name>/news_keywords", methods=["GET"])
 def getNewsWithKeywords_route(llm_name):
-    # get list of keywords as argument from User's request
+    keyword, err = _validate_keyword(request.args.getlist("keywords"))
+    if err:
+        return err
+
     g.news_controller = NewsController(llm_name)
-    user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
-    return render_template("news_key.html", data=data, keyword=user_keywords[0])
+    data = g.news_controller.getNewsWithKeywords(keyword)
+    return render_template("news_key.html", data=data, keyword=keyword)
 
 
 """
@@ -60,11 +96,14 @@ return news based on certain keywords (NO LLM)
 """
 @routes.route("/raw/news_keywords", methods=["GET"])
 def getNewsWithKeywords_raw_route():
+    keyword, err = _validate_keyword(request.args.getlist("keywords"))
+    if err:
+        return err
+
     # Instantiate without a model to bypass LLM initialization entirely
     g.news_controller = NewsController(None)
-    user_keywords = request.args.getlist("keywords")
-    data = g.news_controller.getNewsWithKeywords(user_keywords[0])
-    return render_template("news_key.html", data=data, keyword=user_keywords[0], llm_name="raw")
+    data = g.news_controller.getNewsWithKeywords(keyword)
+    return render_template("news_key.html", data=data, keyword=keyword, llm_name="raw")
 
 
 """

--- a/tests/unitTest.py
+++ b/tests/unitTest.py
@@ -37,7 +37,30 @@ class FlaskAppTestCase(unittest.TestCase):
     def test_news_keywords(self):
         response = self.app.get('/news_keywords?keywords=firewall')
         self.assertEqual(response.status_code, 200)
-    
+
+    # ── Input sanitisation tests (issue #140) ─────────────────────────────────
+
+    def test_keywords_missing_param(self):
+        """No ?keywords= param should return 400, not crash with IndexError."""
+        response = self.app.get('/mistralai/news_keywords')
+        self.assertEqual(response.status_code, 400)
+
+    def test_keywords_empty_string(self):
+        """Blank keyword after stripping should return 400."""
+        response = self.app.get('/mistralai/news_keywords?keywords=   ')
+        self.assertEqual(response.status_code, 400)
+
+    def test_keywords_too_long(self):
+        """Keyword exceeding 200 characters should return 400."""
+        long_keyword = 'a' * 201
+        response = self.app.get(f'/mistralai/news_keywords?keywords={long_keyword}')
+        self.assertEqual(response.status_code, 400)
+
+    def test_raw_keywords_missing_param(self):
+        """Raw endpoint also returns 400 when ?keywords= is missing."""
+        response = self.app.get('/raw/news_keywords')
+        self.assertEqual(response.status_code, 400)
+
     def test_invalid_route(self):
         response = self.app.get('/xxx')
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Description

Added a `_validate_keyword()` helper in `routes/NewsRoutes.py` that validates
the `?keywords=` query parameter before it reaches the controller or database.
Both `/<llm_name>/news_keywords` and `/raw/news_keywords` now use it.

## Related Issue

Fixes #140

## Motivation and Context

The keywords endpoint passed user input directly to Pinecone with zero
validation, causing three problems:

**1. Crash — `IndexError` on missing param**
```
GET /mistralai/news_keywords        ← no ?keywords= provided
→ user_keywords = []
→ user_keywords[0]                  ← IndexError → unhandled 500
```

**2. Empty input passes through**
```
GET /mistralai/news_keywords?keywords=   ← only whitespace
→ blank string gets embedded and sent to Pinecone
→ wastes API quota and returns garbage results
```

**3. No length limit**
```
GET /mistralai/news_keywords?keywords=<10,000 chars>
→ goes straight into HuggingFace embedding call
→ risks hitting token limits and slowing the server
```

## How Has This Been Tested?

Added 4 unit tests in `tests/unitTest.py` covering each validation case:

| Test | Input | Expected |
|---|---|---|
| `test_keywords_missing_param` | no `?keywords=` | 400 |
| `test_keywords_empty_string` | `?keywords=   ` | 400 |
| `test_keywords_too_long` | keyword > 200 chars | 400 |
| `test_raw_keywords_missing_param` | `/raw/news_keywords` no param | 400 |

Results:
```
tests/unitTest.py::FlaskAppTestCase::test_keywords_missing_param     PASSED
tests/unitTest.py::FlaskAppTestCase::test_keywords_empty_string      PASSED
tests/unitTest.py::FlaskAppTestCase::test_keywords_too_long          PASSED
tests/unitTest.py::FlaskAppTestCase::test_raw_keywords_missing_param PASSED

4 passed in 3.29s
```

> Testing environment: Python 3.14.2, Flask test client.
> Validation runs entirely before any external call is made, so dummy
> env vars for Pinecone/HuggingFace are sufficient to run these tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
