### PR TITLE
  fix: move module-level scraping and config inside update_database() (#173)

### DIFF
--- a/db_update/Update.py
+++ b/db_update/Update.py
@@ -6,27 +6,26 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from cybernews.CyberNews import CyberNews
 
-PINECONE_API = dotenv_values(".env").get("PINECONE_API_KEY")
-
-# Configure client
-pc = Pinecone(api_key=PINECONE_API)
-index_name = str.lower(dotenv_values(".env").get("PINECONE_INDEX_NAME")) # pinecone index name must be in lowercase
-
-
-
-
-# Different types of news
-news = CyberNews()
-newsBox = dict()
-newsBox["general_news"] = news.get_news("general")
-newsBox["cyber_attack_news"] = news.get_news("cyberAttack")
-newsBox["vulnerability_news"] = news.get_news("vulnerability")
-newsBox["malware_news"] = news.get_news("malware")
-newsBox["security_news"] = news.get_news("security")
-newsBox["data_breach_news"] = news.get_news("dataBreach")   
-
 # Convert news articles to vectors and upsert into Pinecone
 def update_database(overwrite=(len(sys.argv) > 1 and sys.argv[1] == '--overwrite')):
+    env = dotenv_values(".env")
+    PINECONE_API = env.get("PINECONE_API_KEY")
+    index_name = str.lower(env.get("PINECONE_INDEX_NAME"))  # pinecone index name must be in lowercase
+
+    # Configure client
+    pc = Pinecone(api_key=PINECONE_API)
+
+    # Collect news from all categories
+    news = CyberNews()
+    newsBox = {
+        "general_news":      news.get_news("general"),
+        "cyber_attack_news": news.get_news("cyberAttack"),
+        "vulnerability_news":news.get_news("vulnerability"),
+        "malware_news":      news.get_news("malware"),
+        "security_news":     news.get_news("security"),
+        "data_breach_news":  news.get_news("dataBreach"),
+    }
+
     # Delete the index if overwrite is requested
     if overwrite and index_name in pc.list_indexes().names():
         pc.delete_index(index_name)


### PR DESCRIPTION
## Description

Moved all news collection and Pinecone client initialisation out of module
scope and into `update_database()`, so scraping only runs when the function
is explicitly called — not on import.

## Related Issue

Fixes #173

## Motivation and Context

Lines 9–26 of `db_update/Update.py` were executing at module level:

```python
news = CyberNews()
newsBox["general_news"]       = news.get_news("general")
newsBox["cyber_attack_news"]  = news.get_news("cyberAttack")
newsBox["vulnerability_news"] = news.get_news("vulnerability")
newsBox["malware_news"]       = news.get_news("malware")
newsBox["security_news"]      = news.get_news("security")
newsBox["data_breach_news"]   = news.get_news("dataBreach")
```

This caused three problems:

**1. Import side-effect**
Any script, tool, or test that imported this module immediately triggered
full web scraping across all 6 categories — even if `update_database()`
was never called.

**2. Import failure**
If any single news source timed out or raised an exception during the
module-level scrape, the entire import failed with an unhandled exception,
making the function completely unreachable.

**3. Untestable**
Unit tests could not import the module without hitting live external URLs,
making isolated testing impossible.

## How Has This Been Tested?

Verified that importing the module no longer triggers any scraping:

```
>>> import db_update.Update        # completes instantly
Import done — no scraping triggered.
update_database function exists: True
```

Before this fix, the same import would block for 30–120 seconds
while scraping all news sources.

`update_database()` continues to work correctly when called explicitly:

```bash
python db_update/Update.py
python db_update/Update.py --overwrite
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
