### PR TITLE
fix remove hardcoded ?keywords= from newsKeywordsPath

### DIFF
--- a/static/js/content.js
+++ b/static/js/content.js
@@ -5,19 +5,19 @@ function renderContent(baseLLM) {
             title: "Welcome to b0bot!",
             subtitle: "You are now using Gemma-2b as your base LLM",
             newsPath: "/gemma/news",
-            newsKeywordsPath: "/gemma/news_keywords?keywords="
+            newsKeywordsPath: "/gemma/news_keywords"
         },
         llama: {
             title: "Welcome to b0bot!",
             subtitle: "You are now using Llama-3 as your base LLM",
             newsPath: "/llama/news",
-            newsKeywordsPath: "/llama/news_keywords?keywords="
+            newsKeywordsPath: "/llama/news_keywords"
         },
         mistralai: {
             title: "Welcome to b0bot!",
             subtitle: "You are now using MistralAI as your base LLM",
             newsPath: "/mistralai/news",
-            newsKeywordsPath: "/mistralai/news_keywords?keywords="
+            newsKeywordsPath: "/mistralai/news_keywords"
         }
     };
 


### PR DESCRIPTION
from method=GET automatically append input name=keywords to the action URL. Having ?keywords= hardcoded in path caused deuplicate and empty keyword parameters. Fixes #181

<!--Title: #Fix remove hardcoded ?keywords= from newsKeywordsPath  --->

## Description
<!--- # problem --->
         the newsKeywordsPath in content.js had ?keywords= hardcoded at the end. since the form uses
method="GET" and the input has name='keywords', the browser automatically appends ?keywords=value to action URL.
this caused duplicate or empty keyword parameters being sent to the server.

## Fix
<!--- Removed ?keywords= from all three gemma, llama and mistralai  path in static/js/content.js-->
<!--- The browser now correctly builds the full URL automatically. -->


##Testing
<!--- Tested on /gemma, /llama and /mistralai routes.-->
    keywords now correctly appear in the URL.



## Fixes #181 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
