### PR TITLE
feat: scaffold three-service layout and local Docker Compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-# ─── Docker Compose Infrastructure (GSoC 2026) ───────────────────────────────
 # Copy to .env and adjust as needed. Defaults match docker-compose.yml.
 
 POSTGRES_USER=b0bot

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,21 @@
-# ─── Core Infrastructure ──────────────────────────────────────────────────────
+# ─── Docker Compose Infrastructure (GSoC 2026) ───────────────────────────────
+# Copy to .env and adjust as needed. Defaults match docker-compose.yml.
+
+POSTGRES_USER=b0bot
+POSTGRES_PASSWORD=b0bot
+POSTGRES_DB=b0bot
+POSTGRES_PORT=5433
+DATABASE_URL=postgresql://b0bot:b0bot@localhost:5433/b0bot
+
+REDIS_PORT=6380
+REDIS_URL=redis://localhost:6380/0
+
+# ─── Legacy monolith (removed in follow-up PRs) ──────────────────────────────
 
 # Pinecone Vector DB — get at https://app.pinecone.io
 PINECONE_API_KEY=your_pinecone_api_key_here
 PINECONE_INDEX_NAME=your_pinecone_index_name_here
+
 # HuggingFace Inference API — get at https://huggingface.co/settings/tokens
 HUGGINGFACE_TOKEN=hf_your_token_here
 HF_TOKEN=hf_your_token_here

--- a/api-service/README.md
+++ b/api-service/README.md
@@ -1,0 +1,3 @@
+# api-service
+
+Flask + LangGraph API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: b0bot-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-b0bot}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-b0bot}
+      POSTGRES_DB: ${POSTGRES_DB:-b0bot}
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-b0bot} -d ${POSTGRES_DB:-b0bot}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    container_name: b0bot-redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    ports:
+      - "${REDIS_PORT:-6380}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,4 +1,3 @@
--- B0Bot PostgreSQL schema (GSoC 2026)
 -- Applied automatically on first Postgres container start.
 
 CREATE EXTENSION IF NOT EXISTS vector;

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,78 @@
+-- B0Bot PostgreSQL schema (GSoC 2026)
+-- Applied automatically on first Postgres container start.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE articles (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url              TEXT NOT NULL,
+    url_hash         TEXT NOT NULL,
+    title            TEXT NOT NULL,
+    content          TEXT NOT NULL,
+    summary          TEXT,
+    author           TEXT,
+    source_name      TEXT NOT NULL,
+    feed_url         TEXT,
+    image_url        TEXT,
+    published_at     TIMESTAMPTZ,
+    ingested_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    cve_id           TEXT,
+    severity         TEXT CHECK (severity IN ('CRITICAL', 'HIGH', 'MEDIUM', 'LOW')),
+    affected_system  TEXT,
+    topic_tags       TEXT[] NOT NULL DEFAULT '{}',
+    embedding_status TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (embedding_status IN ('pending', 'indexed', 'failed')),
+    embedding        vector(384),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT articles_url_hash_unique UNIQUE (url_hash)
+);
+
+CREATE INDEX articles_published_at_idx     ON articles (published_at DESC);
+CREATE INDEX articles_source_name_idx      ON articles (source_name);
+CREATE INDEX articles_severity_idx         ON articles (severity);
+CREATE INDEX articles_topic_tags_idx       ON articles USING GIN (topic_tags);
+CREATE INDEX articles_embedding_status_idx ON articles (embedding_status);
+
+CREATE INDEX articles_embedding_hnsw_idx
+    ON articles USING hnsw (embedding vector_cosine_ops);
+
+CREATE TABLE subscribers (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email            TEXT NOT NULL UNIQUE,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'active', 'unsubscribed')),
+    digest_frequency TEXT NOT NULL DEFAULT 'daily'
+                     CHECK (digest_frequency IN ('daily', 'weekly')),
+    otp_hash         TEXT,
+    otp_expires_at   TIMESTAMPTZ,
+    verified_at      TIMESTAMPTZ,
+    digest_sent_at   TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE subscriber_interests (
+    subscriber_id UUID NOT NULL REFERENCES subscribers (id) ON DELETE CASCADE,
+    tag           TEXT NOT NULL,
+    PRIMARY KEY (subscriber_id, tag)
+);
+
+CREATE TABLE digest_deliveries (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscriber_id   UUID NOT NULL REFERENCES subscribers (id),
+    sent_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    article_ids     UUID[] NOT NULL,
+    provider        TEXT,
+    status          TEXT NOT NULL DEFAULT 'sent'
+                    CHECK (status IN ('sent', 'failed')),
+    error_message   TEXT,
+    idempotency_key TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE processed_jobs (
+    idempotency_key TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/ingestion-service/README.md
+++ b/ingestion-service/README.md
@@ -1,0 +1,3 @@
+# ingestion-service
+
+RSS ingestion, BullMQ jobs, pgvector upsert.

--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -1,0 +1,3 @@
+# notification-service
+
+Email digests and subscription delivery.


### PR DESCRIPTION
## Summary
- Add `api-service/`, `ingestion-service/`, `notification-service/` scaffolds
- Add `docker-compose.yml` with Postgres (pgvector) + Redis
- Add `docker/postgres/init.sql` with agreed schema (articles, subscribers, etc.)
- Update `.env.example` with `DATABASE_URL` and `REDIS_URL` (ports 5433/6380)

## Test plan
- [x] `docker compose up -d`
- [x] Postgres reachable on `localhost:5433`
- [x] Redis reachable on `localhost:6380`
- [x] `\dt` shows 5 tables + pgvector extension