### PR TITLE
feat: Postgres + pgvector migration, Docker Compose stack, and service scaffolds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,19 @@
-# ─── Core Infrastructure ──────────────────────────────────────────────────────
+# ─── Postgres (pgvector) ──────────────────────────────────────────────────────
+# Provisions the database in docker-compose. Each service builds its
+# DATABASE_URL from these values (see docker-compose.yml).
+POSTGRES_DB=b0bot
+POSTGRES_USER=b0bot
+POSTGRES_PASSWORD=b0bot
 
-# Pinecone Vector DB — get at https://app.pinecone.io
-PINECONE_API_KEY=your_pinecone_api_key_here
-PINECONE_INDEX_NAME=your_pinecone_index_name_here
-# HuggingFace Inference API — get at https://huggingface.co/settings/tokens
+# ─── Redis ────────────────────────────────────────────────────────────────────
+# Queue, API response cache, and chat session memory.
+# REDIS_URL is wired per service in docker-compose (redis://redis:6379/0).
+
+# ─── HuggingFace Inference API ────────────────────────────────────────────────
+# Get a token at https://huggingface.co/settings/tokens
 HUGGINGFACE_TOKEN=hf_your_token_here
-HF_TOKEN=hf_your_token_here
 
 # ─── Optional Social Connectors ───────────────────────────────────────────────
-# Leave blank to disable. The connector will silently skip if key is absent.
-
-# NewsAPI.org — free key (100 req/day) at https://newsapi.org/register
-NEWSAPI_KEY=your_newsapi_key_here
-
-# YouTube Data API v3 — free key (10,000 units/day)
-# Setup: https://console.cloud.google.com → Enable "YouTube Data API v3"
-YOUTUBE_API_KEY=your_youtube_api_key_here
+# Leave blank to disable. The connector silently skips if the key is absent.
+NEWSAPI_KEY=
+YOUTUBE_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,14 @@
 POSTGRES_DB=b0bot
 POSTGRES_USER=b0bot
 POSTGRES_PASSWORD=b0bot
+POSTGRES_PORT=5433
+DATABASE_URL=postgresql://b0bot:b0bot@localhost:5433/b0bot
 
 # ─── Redis ────────────────────────────────────────────────────────────────────
 # Queue, API response cache, and chat session memory.
-# REDIS_URL is wired per service in docker-compose (redis://redis:6379/0).
+REDIS_PORT=6380
+REDIS_URL=redis://localhost:6380/0
+# Inside Docker network, services use redis://redis:6379/0 (see docker-compose.yml).
 
 # ─── HuggingFace Inference API ────────────────────────────────────────────────
 # Get a token at https://huggingface.co/settings/tokens

--- a/api-service/.dockerignore
+++ b/api-service/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.venv
+.pytest_cache

--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir --default-timeout=120 -r requirements.txt
 
 COPY . .
 

--- a/api-service/config/Database.py
+++ b/api-service/config/Database.py
@@ -1,7 +1,28 @@
-# Pinecone replaced by pgvector in GSoC 2026
-# This is a mock client to keep imports from breaking during transition
-class MockPineconeClient:
-    def Index(self, name):
-        return None
+"""Postgres connection helper.
 
-client = MockPineconeClient()
+Replaces the previous Pinecone client. Structured article data and vector
+search now live in Postgres + pgvector, so the rest of the app talks to a
+single database. A simple per-call connection is enough for current traffic;
+this is the seam where a pooled connection can drop in later if the workers
+put the database under load.
+"""
+import os
+from contextlib import contextmanager
+
+import psycopg
+from psycopg.rows import dict_row
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://b0bot:b0bot@localhost:5432/b0bot",
+)
+
+
+@contextmanager
+def get_connection():
+    """Yield a short-lived Postgres connection that returns rows as dicts."""
+    conn = psycopg.connect(DATABASE_URL, row_factory=dict_row)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/api-service/models/NewsModel.py
+++ b/api-service/models/NewsModel.py
@@ -1,27 +1,61 @@
-# Pinecone replaced by pgvector in GSoC 2026
-# Mock implementation to keep the app running during transition
+"""Postgres-backed news store.
+
+Replaces the previous Pinecone-backed model. Reads articles from the `articles`
+table and returns them in the dict shape the rest of the app already expects
+(`headlines`, `author`, `newsDate`, `newsURL`, `newsImgURL`, `fullNews`), so
+controllers, services, and the scraper agent need no changes.
+
+Keyword lookups currently use a case-insensitive text filter. Vector similarity
+search over the `embedding` column lands once the ingestion service starts
+writing embeddings; `search_type` / `alpha` are accepted now to keep that
+call signature stable.
+"""
+import logging
+
+from config.Database import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Map article columns to the dict keys the rest of the app consumes.
+# Aliases are quoted to preserve their mixed case through Postgres.
+_BASE_SELECT = """
+    SELECT
+        title                                AS headlines,
+        author,
+        to_char(published_at, 'DD/MM/YYYY')  AS "newsDate",
+        url                                  AS "newsURL",
+        image_url                            AS "newsImgURL",
+        content                              AS "fullNews"
+    FROM articles
+"""
+
 
 class CybernewsDB:
-    def __init__(self):
-        pass
+    def get_news_collections(self, is_keyword=False, keyword=None,
+                             search_type="hybrid", alpha=0.3, limit=50):
+        """Return the most recent articles, optionally filtered by keyword.
 
-    def get_news_collections(self, is_keyword=False, keyword=None, search_type="hybrid", alpha=0.3):
-        # Returns mock data until pgvector is wired in by Aqib
-        return [
-            {
-                "headlines": "Mock Article: CVE-2024-1234 Critical Vulnerability Discovered",
-                "author": "Security Researcher",
-                "newsDate": "27/05/2026",
-                "newsURL": "https://example.com/cve-2024-1234",
-                "newsImgURL": "N/A",
-                "fullNews": "A critical vulnerability has been discovered affecting multiple systems.",
-            },
-            {
-                "headlines": "Mock Article: Ransomware Attack Targets Healthcare Sector",
-                "author": "Cyber News Team",
-                "newsDate": "26/05/2026",
-                "newsURL": "https://example.com/ransomware-healthcare",
-                "newsImgURL": "N/A",
-                "fullNews": "A new ransomware campaign is targeting hospitals and healthcare providers.",
-            },
-        ]
+        Returns an empty list (and logs) if the database is unreachable, so a
+        DB outage degrades the API rather than crashing it.
+        """
+        try:
+            with get_connection() as conn, conn.cursor() as cur:
+                if is_keyword and keyword:
+                    cur.execute(
+                        _BASE_SELECT
+                        + " WHERE title ILIKE %(kw)s OR content ILIKE %(kw)s"
+                        + " ORDER BY published_at DESC NULLS LAST"
+                        + " LIMIT %(limit)s",
+                        {"kw": f"%{keyword}%", "limit": limit},
+                    )
+                else:
+                    cur.execute(
+                        _BASE_SELECT
+                        + " ORDER BY published_at DESC NULLS LAST"
+                        + " LIMIT %(limit)s",
+                        {"limit": limit},
+                    )
+                return cur.fetchall()
+        except Exception as exc:
+            logger.error("Failed to fetch articles from Postgres: %s", exc)
+            return []

--- a/api-service/requirements.txt
+++ b/api-service/requirements.txt
@@ -13,4 +13,6 @@ feedparser
 google-api-python-client
 newsapi-python
 redis
+psycopg[binary]
+pgvector
 gunicorn

--- a/api-service/requirements.txt
+++ b/api-service/requirements.txt
@@ -4,7 +4,6 @@ langchain-classic
 langchain-community
 langgraph
 huggingface_hub
-sentence-transformers
 beautifulsoup4
 lxml
 httpx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-b0bot}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-b0bot}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5433}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -23,7 +23,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6380}:6379"
     volumes:
       - redis_data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+# Local development stack for B0Bot.
+# Brings up shared infrastructure (Postgres + pgvector, Redis) and the three
+# services with a single `docker compose up`. No cloud dependencies.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-b0bot}
+      POSTGRES_USER: ${POSTGRES_USER:-b0bot}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-b0bot}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-b0bot} -d ${POSTGRES_DB:-b0bot}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api-service:
+    build: ./api-service
+    ports:
+      - "5000:5000"
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-b0bot}:${POSTGRES_PASSWORD:-b0bot}@postgres:5432/${POSTGRES_DB:-b0bot}
+      REDIS_URL: redis://redis:6379/0
+      HUGGINGFACE_TOKEN: ${HUGGINGFACE_TOKEN:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  ingestion-service:
+    build: ./ingestion-service
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-b0bot}:${POSTGRES_PASSWORD:-b0bot}@postgres:5432/${POSTGRES_DB:-b0bot}
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  notification-service:
+    build: ./notification-service
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-b0bot}:${POSTGRES_PASSWORD:-b0bot}@postgres:5432/${POSTGRES_DB:-b0bot}
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,113 @@
+-- B0Bot database schema.
+-- Runs automatically on first container start (mounted into
+-- /docker-entrypoint-initdb.d). Replaces the previous Pinecone vector store:
+-- structured article data and vector search now live together in Postgres.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ─── Articles (structured + vector) ──────────────────────────
+CREATE TABLE IF NOT EXISTS articles (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url              TEXT NOT NULL,
+    url_hash         TEXT NOT NULL,              -- SHA-256 of normalized URL (dedup key)
+    title            TEXT NOT NULL,
+    content          TEXT NOT NULL,              -- raw/snippet body from RSS
+    summary          TEXT,                       -- LLM summary (filled later by agent)
+    author           TEXT,
+    source_name      TEXT NOT NULL,              -- e.g. "The Hacker News", "Cyware"
+    feed_url         TEXT,                       -- RSS feed URL this article came from
+    image_url        TEXT,
+    published_at     TIMESTAMPTZ,
+    ingested_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    cve_id           TEXT,                       -- e.g. CVE-2024-1234 (nullable at ingest)
+    severity         TEXT CHECK (severity IN ('CRITICAL','HIGH','MEDIUM','LOW')),
+    affected_system  TEXT,
+    topic_tags       TEXT[] NOT NULL DEFAULT '{}',
+    embedding_status TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (embedding_status IN ('pending','indexed','failed')),
+    embedding        vector(384),               -- NULL until embed worker runs
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT articles_url_hash_unique UNIQUE (url_hash)
+);
+
+CREATE INDEX IF NOT EXISTS articles_published_at_idx     ON articles (published_at DESC);
+CREATE INDEX IF NOT EXISTS articles_source_name_idx      ON articles (source_name);
+CREATE INDEX IF NOT EXISTS articles_severity_idx         ON articles (severity);
+CREATE INDEX IF NOT EXISTS articles_topic_tags_idx       ON articles USING GIN (topic_tags);
+CREATE INDEX IF NOT EXISTS articles_embedding_status_idx ON articles (embedding_status);
+
+CREATE INDEX IF NOT EXISTS articles_embedding_hnsw_idx
+    ON articles USING hnsw (embedding vector_cosine_ops);
+
+-- ─── Subscriptions ───────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS subscribers (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email            TEXT NOT NULL UNIQUE,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending','active','unsubscribed')),
+    digest_frequency TEXT NOT NULL DEFAULT 'daily'
+                     CHECK (digest_frequency IN ('daily','weekly')),
+    otp_hash         TEXT,
+    otp_expires_at   TIMESTAMPTZ,
+    verified_at      TIMESTAMPTZ,
+    digest_sent_at   TIMESTAMPTZ,               -- last digest sent (prevent duplicates)
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS subscriber_interests (
+    subscriber_id UUID NOT NULL REFERENCES subscribers(id) ON DELETE CASCADE,
+    tag           TEXT NOT NULL,                 -- e.g. Malware, Ransomware, CVE
+    PRIMARY KEY (subscriber_id, tag)
+);
+
+-- ─── Digest delivery log ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS digest_deliveries (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscriber_id   UUID NOT NULL REFERENCES subscribers(id),
+    sent_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    article_ids     UUID[] NOT NULL,
+    provider        TEXT,
+    status          TEXT NOT NULL DEFAULT 'sent'
+                    CHECK (status IN ('sent','failed')),
+    error_message   TEXT,
+    idempotency_key TEXT NOT NULL UNIQUE
+);
+
+-- ─── Queue idempotency markers ─────────────────────────────────
+CREATE TABLE IF NOT EXISTS processed_jobs (
+    idempotency_key TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── Seed data ─────────────────────────────────────────────────
+-- A few sample articles so the API and UI have something to render before the
+-- ingestion service is online. url_hash is derived the same way ingestion will
+-- derive it, so re-ingesting these URLs is a no-op (ON CONFLICT DO NOTHING).
+INSERT INTO articles (url, url_hash, title, content, author, source_name,
+                      published_at, severity, topic_tags, embedding_status)
+VALUES
+    ('https://thehackernews.com/sample/critical-rce-apache',
+     encode(digest('https://thehackernews.com/sample/critical-rce-apache', 'sha256'), 'hex'),
+     'Critical RCE found in Apache HTTP Server',
+     'A critical remote code execution vulnerability was disclosed affecting multiple versions of the Apache HTTP Server. Administrators are urged to patch immediately.',
+     'The Hacker News',
+     'The Hacker News',
+     NOW() - INTERVAL '1 day',
+     'CRITICAL',
+     ARRAY['CVE','RCE'],
+     'pending'),
+    ('https://www.bleepingcomputer.com/sample/ransomware-healthcare',
+     encode(digest('https://www.bleepingcomputer.com/sample/ransomware-healthcare', 'sha256'), 'hex'),
+     'Ransomware campaign targets healthcare providers',
+     'A new ransomware campaign is actively targeting hospitals and healthcare providers, encrypting patient record systems and demanding payment.',
+     'Bleeping Computer',
+     'Bleeping Computer',
+     NOW() - INTERVAL '2 days',
+     'HIGH',
+     ARRAY['Ransomware','Healthcare'],
+     'pending')
+ON CONFLICT (url_hash) DO NOTHING;

--- a/ingestion-service/Dockerfile
+++ b/ingestion-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "worker.py"]

--- a/ingestion-service/README.md
+++ b/ingestion-service/README.md
@@ -1,0 +1,27 @@
+# ingestion-service
+
+Polls cybersecurity RSS feeds, deduplicates articles by URL hash, embeds them,
+and upserts the results into Postgres + pgvector. Communicates with the rest of
+the system only through Postgres and the job queue — never by importing another
+service.
+
+## Status
+
+Scaffold. The service starts and idles; the RSS poll, dedup, embedding, and
+`article.discovered` enqueue pipeline are implemented in later weeks.
+
+## Run
+
+Started as part of the root `docker-compose.yml`:
+
+```bash
+docker compose up ingestion-service
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DATABASE_URL` | `postgresql://b0bot:b0bot@postgres:5432/b0bot` | Postgres connection |
+| `REDIS_URL` | `redis://redis:6379/0` | Queue / cache |
+| `INGESTION_POLL_INTERVAL` | `300` | Seconds between RSS polls |

--- a/ingestion-service/requirements.txt
+++ b/ingestion-service/requirements.txt
@@ -1,0 +1,4 @@
+python-dotenv
+redis
+psycopg[binary]
+feedparser

--- a/ingestion-service/worker.py
+++ b/ingestion-service/worker.py
@@ -1,0 +1,33 @@
+"""Ingestion service entrypoint.
+
+Polls RSS feeds, deduplicates articles by URL hash, and enqueues
+``article.discovered`` jobs for the embedding worker to upsert into
+Postgres + pgvector.
+
+This is a scaffold. The polling, dedup, and embedding pipeline land in the
+ingestion weeks of the timeline. For now the service starts cleanly and idles,
+so it can be wired into the compose stack alongside Postgres and Redis.
+"""
+import logging
+import os
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("ingestion-service")
+
+POLL_INTERVAL_SECONDS = int(os.getenv("INGESTION_POLL_INTERVAL", "300"))
+
+
+def main() -> None:
+    logger.info("ingestion-service starting (poll interval: %ss)", POLL_INTERVAL_SECONDS)
+    logger.info("RSS polling + queue pipeline not implemented yet — idling")
+    while True:
+        # Real RSS poll -> dedup by url_hash -> enqueue article.discovered.
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "worker.py"]

--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -1,0 +1,28 @@
+# notification-service
+
+Schedules and sends email digests to subscribers. Reads subscriber preferences
+and matching articles from Postgres, sends over SMTP, and records each delivery
+in `digest_deliveries` for idempotency. Communicates only through Postgres and
+the job queue — never by importing another service.
+
+## Status
+
+Scaffold. The service starts and idles; digest scheduling, article matching,
+and SMTP delivery are implemented in the subscription weeks.
+
+## Run
+
+Started as part of the root `docker-compose.yml`:
+
+```bash
+docker compose up notification-service
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DATABASE_URL` | `postgresql://b0bot:b0bot@postgres:5432/b0bot` | Postgres connection |
+| `REDIS_URL` | `redis://redis:6379/0` | Queue / cache |
+| `DIGEST_CHECK_INTERVAL` | `3600` | Seconds between digest checks |
+| `SMTP_HOST` / `SMTP_PORT` | — | SMTP server (Mailhog added later) |

--- a/notification-service/requirements.txt
+++ b/notification-service/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+redis
+psycopg[binary]

--- a/notification-service/worker.py
+++ b/notification-service/worker.py
@@ -1,0 +1,36 @@
+"""Notification service entrypoint.
+
+Schedules digest jobs, reads subscriber preferences from Postgres, matches
+recent articles, and sends email digests over SMTP. Delivery is recorded in
+``digest_deliveries`` so a digest is never sent twice.
+
+This is a scaffold. The scheduler, article matching, and SMTP sending land in
+the subscription weeks of the timeline. For now the service starts cleanly and
+idles, so it can be wired into the compose stack alongside Postgres and Redis.
+"""
+import logging
+import os
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger("notification-service")
+
+DIGEST_CHECK_INTERVAL_SECONDS = int(os.getenv("DIGEST_CHECK_INTERVAL", "3600"))
+
+
+def main() -> None:
+    logger.info(
+        "notification-service starting (check interval: %ss)",
+        DIGEST_CHECK_INTERVAL_SECONDS,
+    )
+    logger.info("Digest scheduling + SMTP delivery not implemented yet — idling")
+    while True:
+        # Read subscriber prefs -> match articles -> send digest -> log delivery.
+        time.sleep(DIGEST_CHECK_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduce the docker setup by running one command whole project start running. I also have create separate folder so they will loosely couple to each other and collaborators can work on tasks without
 any merged conflicts. I have also setup the postgress + pgvetor replacing our current database entirely. These changes include like bsaic schema creation etc.

## Related Issue
N/A

## Motivation and Context

Old setup need necessary improvements like Pinecone replacement with PostgreSQL so we can save user , subscription details and embedding as well.  ingestion and API were in one monolith. Now everything can run locally with Docker, no cloud dependency.


## How Has This Been Tested?
How Has This Been Tested?

Environment: Docker Compose (local), Python 3.11.


1. `docker compose up --build -d`
2. `docker compose ps` — all services up, postgres/redis healthy
3. `curl localhost:5000/health` → `{"status":"ok"}`
4. Open `http://localhost:5000/raw/news` — shows 2 seed articles



## Screenshots (if appropriate):

<img width="782" height="756" alt="image" src="https://github.com/user-attachments/assets/3fb062c8-9b52-4470-b142-e1919a19e35d" />
<img width="1920" height="980" alt="image" src="https://github.com/user-attachments/assets/0ab0724a-c48e-4779-b3e7-578461a43a82" />
<img width="907" height="295" alt="image" src="https://github.com/user-attachments/assets/018006a8-c450-493e-bff3-d7e169ebe1af" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
