### PR TITLE
feat: implement NotificationAgent and multi-turn chat session storage in Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The api-service runs every `/chat` request through a LangGraph pipeline of agent
 2. **ScraperAgent** - queries PostgreSQL for matching articles, falling back to recent articles if no keyword match is found
 3. **AnalyzerAgent** - computes keyword frequency, trending topics, and sentiment (positive/negative/neutral) across the retrieved articles
 4. **ResponderAgent** - checks Redis for a cached response first (5 minute TTL), otherwise builds the JSON response and caches it
+5. **NotificationAgent** - triggered when intent is subscribe; extracts email and frequency from the user message, pushes an article.digest job to Redis for the notification-service to consume
 
 ### Example /chat response
 
@@ -134,6 +135,9 @@ The api-service runs every `/chat` request through a LangGraph pipeline of agent
   }
 }
 ```
+### Multi-turn Session Memory
+
+Every `/chat` request accepts a `session_id`. Chat history for that session is stored in Redis with a 1 hour TTL and capped at 10 messages. Each request loads the history from Redis before invoking the pipeline and saves the updated history after, so follow-up questions have context from previous turns.
 
 ## Licensing
 

--- a/api-service/agents/__init__.py
+++ b/api-service/agents/__init__.py
@@ -4,6 +4,12 @@ from agents.planner import planner_agent
 from agents.scraper import scraper_agent
 from agents.analyzer import analyzer_agent
 from agents.responder import responder_agent
+from agents.notification import notification_agent
+
+def _route_after_planner(state: PlannerState) -> str:
+    if state.get("intent") == "subscribe":
+        return "notification"
+    return "scraper"
 
 def build_graph():
     graph = StateGraph(PlannerState)
@@ -12,11 +18,16 @@ def build_graph():
     graph.add_node("scraper", scraper_agent)
     graph.add_node("analyzer", analyzer_agent)
     graph.add_node("responder", responder_agent)
+    graph.add_node("notification", notification_agent)
 
     graph.set_entry_point("planner")
-    graph.add_edge("planner", "scraper")
+    graph.add_conditional_edges("planner", _route_after_planner, {
+        "scraper": "scraper",
+        "notification": "notification",
+    })
     graph.add_edge("scraper", "analyzer")
     graph.add_edge("analyzer", "responder")
+    graph.add_edge("notification", "responder")
     graph.add_edge("responder", END)
 
     return graph.compile()

--- a/api-service/agents/notification.py
+++ b/api-service/agents/notification.py
@@ -1,0 +1,56 @@
+import re
+import json
+import hashlib
+import os
+import redis
+from agents.state import PlannerState
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+DIGEST_QUEUE = "digest-jobs"
+
+try:
+    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+except Exception:
+    redis_client = None
+
+def _extract_email(text: str) -> str:
+    match = re.search(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", text)
+    return match.group(0) if match else ""
+
+def _extract_frequency(text: str) -> str:
+    if "weekly" in text.lower():
+        return "weekly"
+    return "daily"
+
+def notification_agent(state: PlannerState) -> PlannerState:
+    user_input = state.get("user_input", "")
+    keywords = state.get("keywords", [])
+
+    email = _extract_email(user_input)
+    frequency = _extract_frequency(user_input)
+    # keywords from PlannerAgent become the subscriber's interest tags
+    interests = [k for k in keywords if k not in {"subscribe", "notify", "alert", "digest", "to", "for", "me", "daily", "weekly"}]
+
+    payload = {
+        "email": email,
+        "frequency": frequency,
+        "interests": interests,
+    }
+
+    idempotency_key = "digest:" + hashlib.md5(
+        f"{email}:{frequency}".encode()
+    ).hexdigest()
+
+    job = {
+        "event_type": "article.digest",
+        "idempotency_key": idempotency_key,
+        "payload": payload,
+    }
+
+    if redis_client:
+        try:
+            redis_client.lpush(DIGEST_QUEUE, json.dumps(job))
+        except Exception:
+            pass
+
+    return {**state, "notification_triggered": True}

--- a/api-service/agents/responder.py
+++ b/api-service/agents/responder.py
@@ -22,6 +22,10 @@ def responder_agent(state: PlannerState) -> PlannerState:
     user_input = state.get("user_input", "")
     intent = state.get("intent", "search")
 
+    if intent == "subscribe":
+        response = {"message": "Subscribed successfully. You will receive digests based on your interests.", "articles": []}
+        return {**state, "llm_response": json.dumps(response)}
+
     cache_key = _cache_key(user_input, intent)
 
     if redis_client:

--- a/api-service/agents/responder.py
+++ b/api-service/agents/responder.py
@@ -18,7 +18,6 @@ def _cache_key(user_input: str, intent: str) -> str:
 
 def responder_agent(state: PlannerState) -> PlannerState:
     articles = state.get("retrieved_articles", [])
-    chat_history = state.get("chat_history", [])
     analysis = state.get("analysis", None)
     user_input = state.get("user_input", "")
     intent = state.get("intent", "search")
@@ -39,7 +38,6 @@ def responder_agent(state: PlannerState) -> PlannerState:
         response = {
             "message": f"Found {len(articles)} articles.",
             "articles": articles,
-            "chat_history": chat_history,
             "analysis": analysis,
         }
 

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -1,7 +1,39 @@
 from flask import *
 from controllers.NewsController import NewsController
+import json
+import os
+import redis
+
 routes = Blueprint("routes", __name__)
-# news_controller = NewsController("mistralai") # default model name
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+SESSION_TTL = 3600  # 1 hour
+MAX_HISTORY = 10
+
+try:
+    session_store = redis.from_url(REDIS_URL, decode_responses=True)
+except Exception:
+    session_store = None
+
+def _session_key(session_id: str) -> str:
+    return f"session:{session_id}:history"
+
+def _load_history(session_id: str) -> list:
+    if not session_store:
+        return []
+    try:
+        raw = session_store.get(_session_key(session_id))
+        return json.loads(raw) if raw else []
+    except Exception:
+        return []
+
+def _save_history(session_id: str, history: list):
+    if not session_store:
+        return
+    try:
+        session_store.setex(_session_key(session_id), SESSION_TTL, json.dumps(history))
+    except Exception:
+        pass
 
 """
 home page route
@@ -10,17 +42,15 @@ home page route
 def home_route():
     return render_template("home.html")
 
-
 """
 set route for different LLM models
 """
 @routes.route("/<llm_name>", methods=["GET"])
 def set_llm_route(llm_name):
     if llm_name == "favicon.ico":
-        return "", 204  # No Content response for favicon requests
+        return "", 204
     g.news_controller = NewsController(llm_name)
     return render_template("llm.html", llm_name=llm_name)
-
 
 """
 return news without considering keywords
@@ -31,41 +61,34 @@ def getNews_route(llm_name):
     news = g.news_controller.getNews()
     return render_template("news.html", data=news)
 
-
 """
 return news based on certain keywords
 """
 @routes.route("/<llm_name>/news_keywords", methods=["GET"])
 def getNewsWithKeywords_route(llm_name):
-    # get list of keywords as argument from User's request
     g.news_controller = NewsController(llm_name)
     user_keywords = request.args.getlist("keywords")
     data = g.news_controller.getNewsWithKeywords(user_keywords[0])
     return render_template("news_key.html", data=data, keyword=user_keywords[0])
-
 
 """
 return news without considering keywords (NO LLM)
 """
 @routes.route("/raw/news", methods=["GET"])
 def getNews_raw_route():
-    # Instantiate without a model to bypass LLM initialization entirely
     g.news_controller = NewsController(None)
     news = g.news_controller.getNews()
     return render_template("news.html", data=news, llm_name="raw")
-
 
 """
 return news based on certain keywords (NO LLM)
 """
 @routes.route("/raw/news_keywords", methods=["GET"])
 def getNewsWithKeywords_raw_route():
-    # Instantiate without a model to bypass LLM initialization entirely
     g.news_controller = NewsController(None)
     user_keywords = request.args.getlist("keywords")
     data = g.news_controller.getNewsWithKeywords(user_keywords[0])
     return render_template("news_key.html", data=data, keyword=user_keywords[0], llm_name="raw")
-
 
 """
 deal requests with wrong route
@@ -82,7 +105,7 @@ def health_route():
     return jsonify({"status": "ok"}), 200
 
 """
-chat route — multi-turn dialogue via LangGraph agents
+chat route - multi-turn dialogue via LangGraph agents
 """
 @routes.route("/chat", methods=["POST"])
 def chat_route():
@@ -93,15 +116,23 @@ def chat_route():
     if not user_input:
         return jsonify({"error": "message is required"}), 400
 
+    history = _load_history(session_id)
+
     from agents import agent_graph
     result = agent_graph.invoke({
         "user_input": user_input,
         "session_id": session_id,
-        "chat_history": [],
+        "chat_history": history,
         "notification_triggered": False,
     })
 
-    return jsonify({"response": result["llm_response"]}), 200
+    response = result["llm_response"]
+
+    history.append({"role": "user", "content": user_input})
+    history.append({"role": "assistant", "content": response})
+    _save_history(session_id, history[-MAX_HISTORY:])
+
+    return jsonify({"response": response}), 200
 
 """
 subscribe stub route

--- a/api-service/routes/NewsRoutes.py
+++ b/api-service/routes/NewsRoutes.py
@@ -7,8 +7,8 @@ import redis
 routes = Blueprint("routes", __name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-SESSION_TTL = 3600  # 1 hour
-MAX_HISTORY = 10
+SESSION_TTL = int(os.getenv("SESSION_TTL", "3600"))
+MAX_HISTORY = int(os.getenv("MAX_HISTORY", "10"))
 
 try:
     session_store = redis.from_url(REDIS_URL, decode_responses=True)


### PR DESCRIPTION
## Description
Adds NotificationAgent to the LangGraph pipeline, triggered when PlannerAgent classifies intent as `subscribe`. It extracts email via regex and frequency (`daily`/`weekly`) from user input, filters PlannerAgent keywords against a stop word set to build interest tags, and pushes an `article.digest` job to the `digest-jobs` Redis list via `lpush` with an idempotency key (MD5 of email:frequency). Falls through silently if Redis is down. Uses `redis-py lpush` instead of the `bullmq` Python library which is unstable, the decoupling is identical.

Also adds conditional routing in `__init__.py`: `_route_after_planner()` routes to `notification` if intent is `subscribe`, else `scraper`. Replaced the hard `planner -> scraper` edge with `add_conditional_edges`. Added `notification -> responder` edge. Graph now has two paths: `planner -> scraper -> analyzer -> responder -> END` or `planner -> notification -> responder -> END`.

Adds multi-turn session memory in `NewsRoutes.py`. Each `/chat` request accepts a `session_id`. History is stored in Redis under `session:{session_id}:history` with a 1 hour TTL, capped at 10 messages. History is loaded before graph invoke and saved back after. `chat_history` is passed into LangGraph state only. It is not returned in the API response.

README updated with NotificationAgent as item 5 in the agent pipeline list and a Multi-turn Session Memory subsection. Changes are scoped to `api-service/` only. No changes to `ingestion-service/`, `notification-service/`, `docker-compose.yml`, or any of Aqib's files.

## Related Issue
Closes #207

## Motivation and Context
This is the week 4 deliverable per the agreed GSoC timeline. The pipeline previously had no way to handle subscribe intents or maintain conversation context across turns. NotificationAgent decouples job dispatch from the notification-service. api-service pushes to `digest-jobs`.

## How Has This Been Tested?
Tested locally via `docker compose up -d` with the full stack (Postgres, Redis, api-service). Verified:

- Subscribe curl with email in message returns a response and job appears in `digest-jobs` Redis list
- `redis-cli lrange "digest-jobs" 0 -1` confirms job payload with correct email, frequency, and interest tags
- First message in session `demo_multi` returns articles with `chat_history: []` in graph state
- Follow-up message in same session has previous turn in `chat_history` in graph state
- `redis-cli ttl "session:demo_multi:history"` returns ~3528, confirming 1 hour TTL is active

## Screenshots (if appropriate):
<img width="1074" height="114" alt="Screenshot 2026-06-23 at 12 07 31 PM" src="https://github.com/user-attachments/assets/b3a820e4-7232-4659-b425-92b5ed08fe92" />
<img width="1075" height="135" alt="Screenshot 2026-06-23 at 12 08 17 PM" src="https://github.com/user-attachments/assets/fdc39387-e21b-42de-99d9-f1a9847841f4" />
<img width="1075" height="224" alt="Screenshot 2026-06-23 at 12 09 14 PM" src="https://github.com/user-attachments/assets/a360f46d-80bd-4fb0-beae-fe93354f06a2" />
<img width="1081" height="360" alt="Screenshot 2026-06-23 at 12 10 21 PM" src="https://github.com/user-attachments/assets/6615e17e-8968-4087-bd6b-4c4ab852b234" />
<img width="748" height="67" alt="Screenshot 2026-06-23 at 12 10 56 PM" src="https://github.com/user-attachments/assets/53af0692-6027-4a92-9a42-d49dc74dea77" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.