### PR TITLE
feat(api-service): add pgvector hybrid search to NewsModel and ScraperAgent

### DIFF
--- a/api-service/agents/scraper.py
+++ b/api-service/agents/scraper.py
@@ -1,5 +1,6 @@
 from agents.state import PlannerState
 from models.NewsModel import CybernewsDB
+from services.embeddings import generate_embedding
 
 db = CybernewsDB()
 
@@ -9,13 +10,20 @@ GENERIC_TERMS = {"cybersecurity", "news", "security", "latest", "cyber", "articl
 def scraper_agent(state: PlannerState) -> PlannerState:
     keywords = state.get("keywords", [])
     intent = state.get("intent", "search")
+    user_input = state.get("user_input", "")
 
     # Filter out generic terms to get meaningful keywords
     meaningful_keywords = [k for k in keywords if k.lower() not in GENERIC_TERMS]
 
     if meaningful_keywords and intent == "search":
         keyword_str = " ".join(meaningful_keywords)
-        articles = db.get_news_collections(is_keyword=True, keyword=keyword_str)
+        query_vector = generate_embedding(user_input)
+        articles = db.get_news_collections(
+            is_keyword=True,
+            keyword=keyword_str,
+            search_type="hybrid",
+            query_vector=query_vector or None,
+        )
         # Fall back to all articles if keyword search returns nothing
         if not articles:
             articles = db.get_news_collections()

--- a/api-service/models/NewsModel.py
+++ b/api-service/models/NewsModel.py
@@ -5,14 +5,20 @@ table and returns them in the dict shape the rest of the app already expects
 (`headlines`, `author`, `newsDate`, `newsURL`, `newsImgURL`, `fullNews`), so
 controllers, services, and the scraper agent need no changes.
 
-Keyword lookups currently use a case-insensitive text filter. Vector similarity
-search over the `embedding` column lands once the ingestion service starts
-writing embeddings; `search_type` / `alpha` are accepted now to keep that
-call signature stable.
+Keyword lookups use Postgres full-text search (ts_rank). When a query_vector
+is provided, results are ranked by a weighted blend of text relevance and
+cosine similarity against the embedding column, controlled by alpha. Falls
+back to a plain ILIKE filter when search_type/query_vector are not used, so
+the legacy NewsService caller is unaffected.
 """
 import logging
 
 from config.Database import get_connection
+
+try:
+    from pgvector.psycopg import register_vector
+except ImportError:
+    register_vector = None
 
 logger = logging.getLogger(__name__)
 
@@ -29,18 +35,49 @@ _BASE_SELECT = """
     FROM articles
 """
 
+_HYBRID_SELECT = """
+    SELECT
+        title                                AS headlines,
+        author,
+        to_char(published_at, 'DD/MM/YYYY')  AS "newsDate",
+        url                                  AS "newsURL",
+        image_url                            AS "newsImgURL",
+        content                              AS "fullNews"
+    FROM articles
+    WHERE embedding IS NOT NULL
+    ORDER BY
+        %(alpha)s * ts_rank(to_tsvector('english', title || ' ' || content), plainto_tsquery('english', %(kw)s))
+        + (1 - %(alpha)s) * (1 - (embedding <=> %(query_vector)s::vector)) DESC
+    LIMIT %(limit)s
+"""
+
 
 class CybernewsDB:
     def get_news_collections(self, is_keyword=False, keyword=None,
-                             search_type="hybrid", alpha=0.3, limit=50):
+                             search_type="hybrid", alpha=0.3, limit=50,
+                             query_vector=None):
         """Return the most recent articles, optionally filtered by keyword.
 
+        When query_vector is provided alongside a keyword, uses hybrid
+        ranking (text relevance + vector similarity, weighted by alpha).
         Returns an empty list (and logs) if the database is unreachable, so a
         DB outage degrades the API rather than crashing it.
         """
         try:
             with get_connection() as conn, conn.cursor() as cur:
-                if is_keyword and keyword:
+                if register_vector is not None:
+                    register_vector(conn)
+                if is_keyword and keyword and query_vector:
+                    cur.execute(
+                        _HYBRID_SELECT,
+                        {
+                            "kw": keyword,
+                            "alpha": alpha,
+                            "query_vector": query_vector,
+                            "limit": limit,
+                        },
+                    )
+                elif is_keyword and keyword:
                     cur.execute(
                         _BASE_SELECT
                         + " WHERE title ILIKE %(kw)s OR content ILIKE %(kw)s"

--- a/api-service/requirements.txt
+++ b/api-service/requirements.txt
@@ -15,4 +15,5 @@ newsapi-python==0.2.7
 redis==8.0.1
 psycopg[binary]==3.3.4
 pgvector==0.4.2
+sentence-transformers==5.6.0
 gunicorn==26.0.0

--- a/api-service/services/embeddings.py
+++ b/api-service/services/embeddings.py
@@ -1,0 +1,48 @@
+"""Embedding generation for chat search queries.
+
+Uses ``sentence-transformers/all-MiniLM-L6-v2`` to produce 384-dim vectors
+for hybrid search in pgvector, matching the model ingestion-service uses to
+embed articles.
+"""
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_MODEL = os.getenv(
+    "EMBEDDING_MODEL",
+    "sentence-transformers/all-MiniLM-L6-v2",
+)
+EMBEDDING_DIM = 384
+MAX_TOKEN_LENGTH = 512
+
+_model = None
+
+
+def _get_model():
+    """Lazily load the sentence-transformers model (singleton)."""
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+        logger.info("loading embedding model: %s", EMBEDDING_MODEL)
+        _model = SentenceTransformer(EMBEDDING_MODEL)
+    return _model
+
+
+def generate_embedding(text: str) -> list[float]:
+    """Generate a 384-dim embedding vector for the given query text.
+
+    Input is truncated to ~512 tokens (model max). On failure, an empty
+    list is returned so the caller can fall back to keyword-only search.
+    """
+    if not text or not text.strip():
+        return []
+    try:
+        model = _get_model()
+        # Truncate input to avoid exceeding model context window.
+        truncated = text[:MAX_TOKEN_LENGTH * 4]
+        vector = model.encode(truncated, convert_to_numpy=True)
+        return vector.tolist()
+    except Exception:
+        logger.exception("query embedding generation failed")
+        return []

--- a/api-service/tests/test_news_model.py
+++ b/api-service/tests/test_news_model.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+
+def make_conn_mock():
+    """Build a mock get_connection() context manager returning a mock cursor."""
+    mock_cur = MagicMock()
+    mock_cur_cm = MagicMock()
+    mock_cur_cm.__enter__.return_value = mock_cur
+    mock_cur_cm.__exit__.return_value = False
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur_cm
+
+    mock_conn_cm = MagicMock()
+    mock_conn_cm.__enter__.return_value = mock_conn
+    mock_conn_cm.__exit__.return_value = False
+
+    return mock_conn_cm, mock_cur
+
+
+class TestCybernewsDB:
+    def test_hybrid_query_used_when_query_vector_provided(self, mocker):
+        from models import NewsModel
+
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"headlines": "t"}]
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        mocker.patch.object(NewsModel, "register_vector", MagicMock())
+
+        db = NewsModel.CybernewsDB()
+        vector = [0.1] * 384
+        result = db.get_news_collections(is_keyword=True, keyword="ransomware", query_vector=vector, alpha=0.3, limit=10)
+
+        assert result == [{"headlines": "t"}]
+        sql, params = mock_cur.execute.call_args[0]
+        assert "embedding <=>" in sql
+        assert params == {"kw": "ransomware", "alpha": 0.3, "query_vector": vector, "limit": 10}
+
+    def test_ilike_query_used_when_no_query_vector(self, mocker):
+        from models import NewsModel
+
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = [{"headlines": "t"}]
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        mocker.patch.object(NewsModel, "register_vector", MagicMock())
+
+        db = NewsModel.CybernewsDB()
+        result = db.get_news_collections(is_keyword=True, keyword="ransomware", limit=10)
+
+        assert result == [{"headlines": "t"}]
+        sql, params = mock_cur.execute.call_args[0]
+        assert "ILIKE" in sql
+        assert params == {"kw": "%ransomware%", "limit": 10}
+
+    def test_default_query_when_no_keyword(self, mocker):
+        from models import NewsModel
+
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        mocker.patch.object(NewsModel, "register_vector", MagicMock())
+
+        db = NewsModel.CybernewsDB()
+        result = db.get_news_collections(limit=10)
+
+        assert result == []
+        sql, params = mock_cur.execute.call_args[0]
+        assert "WHERE" not in sql
+        assert params == {"limit": 10}
+
+    def test_returns_empty_list_on_db_error(self, mocker):
+        from models import NewsModel
+
+        mocker.patch.object(NewsModel, "get_connection", side_effect=Exception("connection refused"))
+
+        db = NewsModel.CybernewsDB()
+        result = db.get_news_collections(is_keyword=True, keyword="ransomware")
+
+        assert result == []
+
+    def test_register_vector_called_when_available(self, mocker):
+        from models import NewsModel
+
+        conn_cm, mock_cur = make_conn_mock()
+        mock_cur.fetchall.return_value = []
+        mock_register = MagicMock()
+        mocker.patch.object(NewsModel, "get_connection", return_value=conn_cm)
+        mocker.patch.object(NewsModel, "register_vector", mock_register)
+
+        db = NewsModel.CybernewsDB()
+        db.get_news_collections(limit=10)
+
+        mock_register.assert_called_once()

--- a/api-service/tests/test_scraper.py
+++ b/api-service/tests/test_scraper.py
@@ -27,7 +27,9 @@ class TestScraperAgent:
         from agents.scraper import scraper_agent
         state = make_state(intent="search", keywords=["ransomware", "attack"])
         scraper_agent(state)
-        mock_db.get_news_collections.assert_called_once_with(is_keyword=True, keyword="ransomware attack")
+        mock_db.get_news_collections.assert_called_once_with(
+            is_keyword=True, keyword="ransomware attack", search_type="hybrid", query_vector=None
+        )
 
     def test_generic_terms_filtered_out(self, mocker):
         from agents import scraper as scraper_module
@@ -37,7 +39,9 @@ class TestScraperAgent:
         from agents.scraper import scraper_agent
         state = make_state(intent="search", keywords=["cybersecurity", "news", "ransomware"])
         scraper_agent(state)
-        mock_db.get_news_collections.assert_called_once_with(is_keyword=True, keyword="ransomware")
+        mock_db.get_news_collections.assert_called_once_with(
+            is_keyword=True, keyword="ransomware", search_type="hybrid", query_vector=None
+        )
 
     def test_falls_back_when_all_keywords_are_generic(self, mocker):
         from agents import scraper as scraper_module
@@ -69,3 +73,17 @@ class TestScraperAgent:
         state = make_state(intent="search", keywords=["ransomware"])
         result = scraper_agent(state)
         assert result["retrieved_articles"][0] == {"title": "Test", "source": "Src", "date": "01/01/2026", "url": "http://x.com", "body": "body text"}
+
+    def test_query_embedded_and_passed_to_hybrid_search(self, mocker):
+        from agents import scraper as scraper_module
+        mock_db = MagicMock()
+        mock_db.get_news_collections.return_value = [{"headlines": "t", "author": "x", "newsDate": "01/01/2026", "newsURL": "http://x.com", "fullNews": ""}]
+        mocker.patch.object(scraper_module, "db", mock_db)
+        mock_vector = [0.1] * 384
+        mocker.patch.object(scraper_module, "generate_embedding", return_value=mock_vector)
+        from agents.scraper import scraper_agent
+        state = make_state(intent="search", keywords=["ransomware", "attack"], user_input="latest ransomware attack news")
+        scraper_agent(state)
+        mock_db.get_news_collections.assert_called_once_with(
+            is_keyword=True, keyword="ransomware attack", search_type="hybrid", query_vector=mock_vector
+        )


### PR DESCRIPTION
## Description
ScraperAgent and NewsModel used plain ILIKE text matching before this. NewsModel.get_news_collections already had search_type and alpha params sitting in the signature unused, waiting for this. Now when a query_vector is passed, results are ranked by a weighted blend of postgres full-text search (ts_rank) and cosine similarity over the embedding column, using that same alpha param.

344 of 346 articles already have indexed embeddings from Aqib's poller, the HNSW index already exists too, nothing was actually querying it until now. Falls back to plain ILIKE when no query_vector is passed, so the legacy NewsService caller (still live via NewsRoutes) is unaffected, no breaking changes.

This covers 2 of the 3 items in issue 219, pgvector search and the ScraperAgent update. LLM-generated summaries are a separate PR.

Only touches api-service/, nothing else changed.

## Related Issue
#219

## Motivation and Context
The embedding column and HNSW index have existed since the ingestion service started writing embeddings, but nothing was actually querying them until now.

## How Has This Been Tested?
Ran locally via python3 -m pytest tests/ -v. All 34 tests pass:

- NewsModel: hybrid query used when query_vector is passed, ILIKE fallback when it isn't, default query with no keyword, DB error returns empty list, register_vector called when available
- ScraperAgent: query embedded and passed through to hybrid search

Also verified against real data outside the test suite, ran a live query against the local postgres container ("ransomware attack on hospital") and confirmed it returned relevant ransomware articles ranked correctly. 344 of 346 articles already had indexed embeddings from Aqib's poller, this was the first thing to actually query them.

## Screenshots (if appropriate):
<img width="1187" height="210" alt="image" src="https://github.com/user-attachments/assets/ff9d6f99-f74a-4e5b-b01c-03214a757c4c" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
